### PR TITLE
Add simple GithubAction for Tox

### DIFF
--- a/.github/workflows/flake8_docs.yaml
+++ b/.github/workflows/flake8_docs.yaml
@@ -1,0 +1,24 @@
+name: Python Flake8, Docs
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Tox flake8
+      run: tox -e flake8
+    - name: Tox docs
+      run: tox -e docs      

--- a/.github/workflows/flake8_docs.yaml
+++ b/.github/workflows/flake8_docs.yaml
@@ -1,4 +1,4 @@
-name: Python Flake8, Docs
+name: Python Flake8, Docs, mypy
 
 on:
   - push
@@ -21,4 +21,6 @@ jobs:
     - name: Tox flake8
       run: tox -e flake8
     - name: Tox docs
-      run: tox -e docs      
+      run: tox -e docs
+    - name: Tox mypy
+      run: tox -e mypy


### PR DESCRIPTION
The low-hanging fruit for automatic checks is probably getting tox executed on Github Actions.

I was able to run `flake8` , `mypy` and `docs` successfully.

However I failed with the test suite. We probably need to set up some more things in the environment...

The output of the Github Actions is visible here: https://github.com/ChristianKuehnel/llvm-lnt/actions
