### PR TITLE
Remove outdated note in README (NFC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Testing
 =======
 
 Testing is done by running tox from the top-level directory. It runs the tests
-for both Python 2 and Python 3, it also checks code style.
+for Python 3 and checks code style.


### PR DESCRIPTION
Support for Python2 was dropped back in 2022 by https://github.com/llvm/llvm-lnt/commit/0e3a5f745de6dc1008fcfa1f4ae8076329bd217c .

Remove outdated note in README.