### PR TITLE
[Profile] Fix CFG BB weight calculation

### DIFF
--- a/lnt/server/ui/static/lnt_profile.js
+++ b/lnt/server/ui/static/lnt_profile.js
@@ -19,10 +19,8 @@ function CFGBasicBlock (instructions, fallThruInstruction, cfg) {
     this.targets = gjt[1];
     this.noFallThru = gjt[0];
     this.weight = this.instructions
-        .reduce(function (a,b) {
-            var weight_a = (a.weight === undefined)?0:a.weight;
-            var weight_b = (b.weight === undefined)?0:b.weight;
-            return weight_a+weight_b;
+        .reduce(function (acc,inst) {
+            return acc + ((inst.weight === undefined)?0:inst.weight);
         }, 0);
 };
 


### PR DESCRIPTION
I might be missing something, but the first argument to reduce is the
accumulator which should be a number, not an CFGInstruction.  This
silently failed because .weight on a number is undefined, which just got
subsistuted for 0.
