### PR TITLE
Add --filter and --filter-out arguments to test-suite

### DIFF
--- a/lnt/tests/test_suite.py
+++ b/lnt/tests/test_suite.py
@@ -627,6 +627,11 @@ class TestSuiteTest(BuiltinTest):
                                'perf_profile_events=%s' %
                                self.opts.perf_events]
 
+        if self.opts.filter:
+            extra_args = ['--filter', self.opts.filter]
+        if self.opts.filter_out:
+            extra_args = ['--filter-out', self.opts.filter_out]
+
         logger.info('Testing...')
         try:
             self._check_call([lit_cmd,
@@ -1088,6 +1093,12 @@ class TestSuiteTest(BuiltinTest):
 @click.option("--only-test", "only_test", metavar="PATH",
               type=click.UNPROCESSED, default=None,
               help="Only run tests under PATH")
+@click.option("--filter", metavar="REGEX",
+              help="Only run tests with paths matching the given regular "
+                   "expression")
+@click.option("--filter-out", metavar="REGEX",
+              help="Filter out tests with paths matching the given regular "
+                   "expression")
 # Test Execution
 @click.option("--only-compile", "only_compile",
               help="Don't run the tests, just compile them.", is_flag=True)

--- a/lnt/tests/test_suite.py
+++ b/lnt/tests/test_suite.py
@@ -628,9 +628,9 @@ class TestSuiteTest(BuiltinTest):
                                self.opts.perf_events]
 
         if self.opts.filter:
-            extra_args = ['--filter', self.opts.filter]
+            extra_args += ['--filter', self.opts.filter]
         if self.opts.filter_out:
-            extra_args = ['--filter-out', self.opts.filter_out]
+            extra_args += ['--filter-out', self.opts.filter_out]
 
         logger.info('Testing...')
         try:


### PR DESCRIPTION
Sometimes it's useful to ignore a test you know is failing, or to only
run a subset of tests that may reside in different directories. This
adds flags for --filter and --filter-out which just get passed on to
lit.

They're separate from --only-test and --single-result since they don't
interact with the diagnose or predication stuff.
