### PR TITLE
[Profile] Add CFG support for RISC-V

### DIFF
--- a/lnt/server/ui/static/lnt_profile.js
+++ b/lnt/server/ui/static/lnt_profile.js
@@ -100,6 +100,16 @@ InstructionSetParser.prototype = {
         // TODO: add all control-flow-changing instructions.
     ],
 
+    RISCVJumpTargetRegexps: [
+        // (regexp, noFallThru?)
+        // branch conditional:
+        [new RegExp("^\\s*b[a-z]+\\s+.*(0x[0-9a-f]+)\\s+<.+>"), false],
+        // jumps:
+        [new RegExp("^\\s*(?:jal|j|call|tail)\\s+.+(0x[0-9a-f]+)\\s+<.+>"), true],
+        // indirect jumps:
+        [new RegExp("^\\s*(?:jalr|jr|ret)"), true]
+    ],
+
     X86_64JumpTargetRegexps: [
         // (regexp, noFallThru?)
         // branch conditional:
@@ -513,6 +523,9 @@ Profile.prototype = {
         else if (this.instructionSet == 'aarch32t32')
             instructionParser = new InstructionSetParser(
                 InstructionSetParser.prototype.AArch32T32JumpTargetRegexps);
+        if (this.instructionSet == 'riscv')
+            instructionParser = new InstructionSetParser(
+                InstructionSetParser.prototype.RISCVJumpTargetRegexps);
         else if (this.instructionSet == 'x86_64')
             instructionParser = new InstructionSetParser(
                 InstructionSetParser.prototype.X86_64JumpTargetRegexps);

--- a/lnt/server/ui/static/lnt_profile.js
+++ b/lnt/server/ui/static/lnt_profile.js
@@ -105,7 +105,7 @@ InstructionSetParser.prototype = {
         // branch conditional:
         [new RegExp("^\\s*b[a-z]+\\s+.*(0x[0-9a-f]+)\\s+<.+>"), false],
         // jumps:
-        [new RegExp("^\\s*(?:jal|j|call|tail)\\s+.+(0x[0-9a-f]+)\\s+<.+>"), true],
+        [new RegExp("^\\s*(?:jal|j|call|tail)\\s+.*(0x[0-9a-f]+)\\s+<.+>"), true],
         // indirect jumps:
         [new RegExp("^\\s*(?:jalr|jr|ret)"), true]
     ],

--- a/lnt/server/ui/templates/v4_profile.html
+++ b/lnt/server/ui/templates/v4_profile.html
@@ -93,6 +93,7 @@
         <option value="cfg-aarch64">Control-Flow Graph (AArch64)</option>
         <option value="cfg-aarch32t32">Control-Flow Graph (AArch32-T32)</option>
         <option value="cfg-aarch32a32">Control-Flow Graph (AArch32-A32)</option>
+        <option value="cfg-riscv">Control-Flow Graph (RISC-V)</option>
         <option value="cfg-x86_64">Control-Flow Graph (X86-64)</option>
       </select>
     </div>


### PR DESCRIPTION
The control transfer instructions are the same for both RV32 and RV64, so we only need one set of regexps.
I think this covers all instructions and pseudo-instructions, although I'm not sure if all of them disassembled by objdump.
