### PR TITLE
Fix profile demangling

### DIFF
--- a/lnt/server/ui/static/lnt_profile.js
+++ b/lnt/server/ui/static/lnt_profile.js
@@ -1073,10 +1073,12 @@ function FunctionTypeahead(element, options) {
         },
         updater: function(item) {
             // FIXME: the item isn't passed in as json any more, it's
-            // been rendered ("fname,[object Object]"). Lame. Hack around
-            // this by splitting apart the ','-concatenated 2-tuple again.
-            var splitIndex = item.lastIndexOf(',');
-            fname = item.substr(0, splitIndex);
+            // been rendered. Lame. Hack around this by splitting apart
+            // the ','-concatenated 2-tuple again.
+            // tamar: with C++ symbols demangled we have natural ,s in the
+            //        string so we can't blindly lop off ,.  Instead lets just
+            //        do a safer substring on ,[object Object].
+            fname = item.substr(0, item.length - ",[object Object]".length);
 
             options.updated(fname);
             return fname;


### PR DESCRIPTION
Upstream changed LNT a while ago to store the demangled named for C++ functions.

However the demangled names can contain the character , in them, which makes the split function incorrectly split from the stringified javascript object.

This instead of splitting on `,` splits on `,[object Object]` instead so the lookups succeed.