### PR TITLE
Change /usr/bin/python -> /usr/bin/env python in tests

### DIFF
--- a/tests/runtest/Inputs/test-suite-cmake/fake-lit
+++ b/tests/runtest/Inputs/test-suite-cmake/fake-lit
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import argparse, shutil
 parser = argparse.ArgumentParser(description='dummy lit')

--- a/tests/runtest/Inputs/test-suite-cmake/fake-lit-fails-compile
+++ b/tests/runtest/Inputs/test-suite-cmake/fake-lit-fails-compile
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import argparse, shutil, sys
 parser = argparse.ArgumentParser(description='dummy lit')

--- a/tests/runtest/Inputs/test-suite-cmake/fake-lit-fails-exec
+++ b/tests/runtest/Inputs/test-suite-cmake/fake-lit-fails-exec
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import argparse, shutil, sys
 parser = argparse.ArgumentParser(description='dummy lit')

--- a/tests/runtest/Inputs/test-suite-cmake/fake-lit-profile
+++ b/tests/runtest/Inputs/test-suite-cmake/fake-lit-profile
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import argparse, shutil
 parser = argparse.ArgumentParser(description='dummy lit')

--- a/tests/runtest/Inputs/test-suite-cmake/fake-lit-profile-import
+++ b/tests/runtest/Inputs/test-suite-cmake/fake-lit-profile-import
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import argparse, shutil
 parser = argparse.ArgumentParser(description='dummy lit')


### PR DESCRIPTION
This was needed to get some of the tests passing when using venv (my system doesn't have python3 symlinked to /usr/bin/python, but venv will stick it on the PATH), and it seems to be what PEP 394 recommends: https://peps.python.org/pep-0394/#for-python-script-publishers
