### PR TITLE
Update old unittest asserts in tests

### DIFF
--- a/tests/server/ui/change_processing.py
+++ b/tests/server/ui/change_processing.py
@@ -177,7 +177,7 @@ class ChangeProcessingTests(unittest.TestCase):
             .all()
 
         ret, reg = identify_related_changes(session, ts_db, field_change7, active_indicators)
-        self.assertNotEquals(self.regression, reg)
+        self.assertNotEqual(self.regression, reg)
         self.assertFalse(ret, "No match with different machine and tests.")
         self.regressions.append(reg)
         field_change4 = ts_db.FieldChange(self.order1234,

--- a/tests/server/ui/test_api.py
+++ b/tests/server/ui/test_api.py
@@ -174,7 +174,7 @@ class JSONAPITester(unittest.TestCase):
                     "start_time": "2012-04-11T16:28:23",
                     "id": 1,
                     "llvm_project_revision": u'154331'}
-        self.assertDictContainsSubset(expected, j['run'])
+        self.assertEqual(j['run'], j['run'] | expected)
         self.assertEqual(len(j['tests']), 2)
         # This should not be a run.
         check_json(client, 'api/db_default/v4/nts/runs/100', expected_code=404)

--- a/tests/testing/TestingTest.py
+++ b/tests/testing/TestingTest.py
@@ -336,18 +336,18 @@ class TestRun(unittest.TestCase):
         self.assertEqual(run_datetime_end_v1.report_version, 1)
 
         # Check failure when info contains __report_version__ key.
-        self.assertRaisesRegexp(ValueError, '__report_version__.*reserved',
-                                Run, None, None, info)
+        self.assertRaisesRegex(ValueError, '__report_version__.*reserved',
+                               Run, None, None, info)
 
         # Check missing tag entry in info for format version 1.
-        self.assertRaisesRegexp(ValueError,
-                                "Missing 'tag' entry in 'info' dictionary",
-                                Run, info={'run_order': 40385})
+        self.assertRaisesRegex(ValueError,
+                               "Missing 'tag' entry in 'info' dictionary",
+                               Run, info={'run_order': 40385})
 
         # Check missing run_order entry in info for format version 1.
-        self.assertRaisesRegexp(ValueError,
-                                "Missing 'run_order' entry in 'info'"
-                                " dictionary", Run, info={'tag': 'nts'})
+        self.assertRaisesRegex(ValueError,
+                               "Missing 'run_order' entry in 'info'"
+                               " dictionary", Run, info={'tag': 'nts'})
 
         # Test empty start and end time in format version 2
         self.assertEqual(self.run_float_start_v2.start_time,
@@ -359,10 +359,10 @@ class TestRun(unittest.TestCase):
 
         # Check missing llvm_project_revision entry in info for format
         # version 2.
-        self.assertRaisesRegexp(ValueError,
-                                "Missing 'llvm_project_revision' entry in"
-                                " 'info' dictionary", Run, 0.0, info={},
-                                report_version=2)
+        self.assertRaisesRegex(ValueError,
+                               "Missing 'llvm_project_revision' entry in"
+                               " 'info' dictionary", Run, 0.0, info={},
+                               report_version=2)
 
         # Check call to check()
         self.assertRaises(AssertionError, Run, info=self.info_v2,
@@ -383,8 +383,8 @@ class TestRun(unittest.TestCase):
 
         # Check no time or info.
         self.run_float_start_v2.info = {}
-        self.assertRaisesRegexp(ValueError, 'No data defined in this Run',
-                                self.run_float_start_v2.check)
+        self.assertRaisesRegex(ValueError, 'No data defined in this Run',
+                               self.run_float_start_v2.check)
 
     def test_update(self):
         # Check update with a supplied end time.


### PR DESCRIPTION
These methods seem to have been renamed at least as of Python 3.12, apart from assertDictContainsSubset which was removed. For that it seems like you need to just need to check the superset is the same as the union with the subset.
