### PR TITLE
Automatically set Ninja generator for --use-make=ninja

### DIFF
--- a/lnt/tests/test_suite.py
+++ b/lnt/tests/test_suite.py
@@ -448,6 +448,11 @@ class TestSuiteTest(BuiltinTest):
             defs['CMAKE_CXX_COMPILER'] = self.opts.cxx
         if self.opts.make:
             defs['CMAKE_MAKE_PROGRAM'] = self.opts.make
+        if self.opts.make and (self.opts.make.endswith('ninja') or
+                              self.opts.make.endswith('ninja.exe')):
+            cmake_flags = ['-G', 'Ninja']
+        else:
+            cmake_flags = []
 
         cmake_build_types = ('DEBUG', 'MINSIZEREL', 'RELEASE',
                              'RELWITHDEBINFO')

--- a/lnt/tests/test_suite.py
+++ b/lnt/tests/test_suite.py
@@ -525,7 +525,6 @@ class TestSuiteTest(BuiltinTest):
             self.remote_run = True
 
         # Prepare cmake cache if requested:
-        cmake_flags = []
         for cache in self.opts.cmake_cache:
             if cache == "":
                 continue


### PR DESCRIPTION
When using `--use-make=ninja` or `--use-make=ninja.exe`, the build would previously fail because CMake was not instructed to generate the corresponding Ninja build files. It would default to generating Makefiles for Linux or Visual Studio MSBuild files for Windows.

This change detects when the specified make program is ninja and automatically adds the `-G Ninja` flag to the CMake config step.