### PR TITLE
Fix lnt startup crash on Windows

### DIFF
--- a/lnt/tests/nt.py
+++ b/lnt/tests/nt.py
@@ -12,7 +12,12 @@ import traceback
 import urllib.error
 import shlex
 import pipes
-import resource
+
+try:
+    import resource
+    has_resource = True
+except ImportError:
+    has_resource = False
 
 import click
 
@@ -73,7 +78,8 @@ class TestModule(object):
         return p.wait()
 
     def get_time(self):
-        if self._user_time:
+        # Only get the user time if the 'resource' module is available.
+        if self._user_time and has_resource:
             return resource.getrusage(resource.RUSAGE_CHILDREN).ru_utime
         else:
             return time.time()


### PR DESCRIPTION
Running lnt on Windows fails with an Error as it tries to import the resource module which is not available on windows.

This patch fixes the crash by making the resource module an optional dependency.