### PR TITLE
Bump SQLAlchemy==1.3.24 to support lnt on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ The *LNT* source is available in the llvm-lnt repository:
         "Flask-RESTful==0.3.4",
         "Jinja2==2.11.3",
         "MarkupSafe==1.1.1",
-        "SQLAlchemy==1.2.19",
+        "SQLAlchemy==1.3.24",
         "Werkzeug==0.15.6",
         "itsdangerous==0.24",
         "python-gnupg==0.3.7",


### PR DESCRIPTION
LNT crashes on windows on startup with following error in SQLAlchemy:

AttributeError: module 'time' has no attribute 'clock'

This patch upgrades SQLAlchemy to 1.3.24 which resolves above error.