### PR TITLE
Revert "Handle non-Apple packaged GCC versions"

### DIFF
--- a/lnt/testing/util/compilers.py
+++ b/lnt/testing/util/compilers.py
@@ -76,8 +76,7 @@ def get_cc_info(path, cc_flags=[]):
         logger.error("unable to find compiler version: %r: %r" %
                      (cc, cc_version))
     else:
-        m = re.match(r'(.*) version ([^ ]*) (?:[0-9]+ )?+(\([^(]*\))(.*)',
-                     version_ln)
+        m = re.match(r'(.*) version ([^ ]*) +(\([^(]*\))(.*)', version_ln)
         if m is not None:
             cc_name, cc_version_num, cc_build_string, cc_extra = m.groups()
         else:
@@ -105,17 +104,15 @@ def get_cc_info(path, cc_flags=[]):
         cc_src_tag = cc_version_num
 
     elif cc_name == 'gcc' and (cc_extra == '' or
-                               cc_extra == '(GCC)' or
                                re.match(r' \(dot [0-9]+\)', cc_extra)):
         cc_norm_name = 'gcc'
         m = re.match(r'\(Apple Inc. build ([0-9]*)\)', cc_build_string)
         if m:
             cc_build = 'PROD'
             cc_src_tag, = m.groups()
-        elif 'experimental' in cc_build_string:
-            cc_build = 'DEV'
         else:
-            cc_build = 'PROD'
+            logger.error('unable to determine gcc build version: %r' %
+                         cc_build_string)
     elif (cc_name in ('clang', 'LLVM', 'Debian clang', 'Apple clang',
                       'Apple LLVM') and
           (cc_extra == '' or 'based on LLVM' in cc_extra or

--- a/tests/SharedInputs/FakeCompilers/fakecompiler.py
+++ b/tests/SharedInputs/FakeCompilers/fakecompiler.py
@@ -178,28 +178,6 @@ Thread model: posix""", file=sys.stderr)  # noqa
  "%s" "-cc1" "-E" ... more boring stuff here ...""" % (
             g_program,), file=sys.stderr)
 
-class GCCDebian(FakeCompiler):
-    compiler_name = "gcc-debian"
-
-    def print_verbose_info(self):
-        print("""\
-Target: x86_64-linux-gnu
-gcc version 12.2.0 (Debian 12.2.0-14+deb12u1)""", file=sys.stderr)
-
-    def print_dumpmachine(self):
-        print("x86_64-linux-gnu")
-
-class GCCTrunk(FakeCompiler):
-    compiler_name = "gcc-trunk"
-
-    def print_verbose_info(self):
-        print("""\
-Target: x86_64-linux-gnu
-gcc version 16.0.0 20250807 (experimental) (GCC)""", file=sys.stderr)
-
-    def print_dumpmachine(self):
-        print("x86_64-linux-gnu")
-
 
 fake_compilers = dict((value.compiler_name, value)
                       for key, value in locals().items()

--- a/tests/SharedInputs/FakeCompilers/gcc-debian
+++ b/tests/SharedInputs/FakeCompilers/gcc-debian
@@ -1,1 +1,0 @@
-fakecompiler.py

--- a/tests/SharedInputs/FakeCompilers/gcc-trunk
+++ b/tests/SharedInputs/FakeCompilers/gcc-trunk
@@ -1,1 +1,0 @@
-fakecompiler.py

--- a/tests/testing/Compilers.py
+++ b/tests/testing/Compilers.py
@@ -66,19 +66,3 @@ info = get_info("clang-no-info")
 pprint.pprint(info)
 assert info['cc_name'] == 'clang'
 assert info['cc_version_number'] == '3.2'
-
-# Check a GCC packaged from Debian.
-info = get_info("gcc-debian")
-pprint.pprint(info)
-assert info['cc_name'] == 'gcc'
-assert info['cc_build'] == 'PROD'
-assert info['cc_version_number'] == '12.2.0'
-assert info['cc_target'] == 'x86_64-linux-gnu'
-
-# Check a GCC built from trunk.
-info = get_info("gcc-trunk")
-pprint.pprint(info)
-assert info['cc_name'] == 'gcc'
-assert info['cc_build'] == 'DEV'
-assert info['cc_version_number'] == '16.0.0'
-assert info['cc_target'] == 'x86_64-linux-gnu'


### PR DESCRIPTION
Reverts llvm/llvm-lnt#34 due to an error running the test suite on our Linux bots. https://lab.llvm.org/buildbot/#/builders/17/builds/10167 for example.

```
Traceback (most recent call last):
  File "/home/tcwg-buildbot/worker/clang-aarch64-sve-vla/test/sandbox/bin/lnt", line 33, in <module>
    sys.exit(load_entry_point('LNT', 'console_scripts', 'lnt')())
  File "/home/tcwg-buildbot/worker/clang-aarch64-sve-vla/test/sandbox/lib/python3.10/site-packages/click-6.7-py3.10.egg/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/tcwg-buildbot/worker/clang-aarch64-sve-vla/test/sandbox/lib/python3.10/site-packages/click-6.7-py3.10.egg/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/tcwg-buildbot/worker/clang-aarch64-sve-vla/test/sandbox/lib/python3.10/site-packages/click-6.7-py3.10.egg/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/tcwg-buildbot/worker/clang-aarch64-sve-vla/test/sandbox/lib/python3.10/site-packages/click-6.7-py3.10.egg/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/tcwg-buildbot/worker/clang-aarch64-sve-vla/test/sandbox/lib/python3.10/site-packages/click-6.7-py3.10.egg/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/tcwg-buildbot/worker/clang-aarch64-sve-vla/test/sandbox/lib/python3.10/site-packages/click-6.7-py3.10.egg/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/tcwg-buildbot/worker/clang-aarch64-sve-vla/test/lnt/lnt/tests/test_suite.py", line 1189, in cli_action
    results = test_suite.run_test(test_suite.opts)
  File "/home/tcwg-buildbot/worker/clang-aarch64-sve-vla/test/lnt/lnt/tests/test_suite.py", line 310, in run_test
    cc_info = self._get_cc_info(cmake_vars)
  File "/home/tcwg-buildbot/worker/clang-aarch64-sve-vla/test/lnt/lnt/tests/test_suite.py", line 714, in _get_cc_info
    return lnt.testing.util.compilers.get_cc_info(
  File "/home/tcwg-buildbot/worker/clang-aarch64-sve-vla/test/lnt/lnt/testing/util/compilers.py", line 79, in get_cc_info
    m = re.match(r'(.*) version ([^ ]*) (?:[0-9]+ )?+(\([^(]*\))(.*)',
  File "/usr/lib/python3.10/re.py", line 190, in match
    return _compile(pattern, flags).match(string)
  File "/usr/lib/python3.10/re.py", line 303, in _compile
    p = sre_compile.compile(pattern, flags)
  File "/usr/lib/python3.10/sre_compile.py", line 788, in compile
    p = sre_parse.parse(p, flags)
  File "/usr/lib/python3.10/sre_parse.py", line 955, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
  File "/usr/lib/python3.10/sre_parse.py", line 444, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
  File "/usr/lib/python3.10/sre_parse.py", line 672, in _parse
    raise source.error("multiple repeat",
re.error: multiple repeat at position 33
```