### PR TITLE
Use CMAKE_OBJDUMP when importing profiles in test-suite

### DIFF
--- a/lnt/testing/profile/profile.py
+++ b/lnt/testing/profile/profile.py
@@ -21,10 +21,12 @@ class Profile(object):
         self.impl = impl
 
     @staticmethod
-    def fromFile(f):
+    def fromFile(f, objdump=None):
         """
         Load a profile from a file.
         """
+        if objdump is None:
+            objdump = os.getenv("CMAKE_OBJDUMP", "objdump")
         for impl in lnt.testing.profile.IMPLEMENTATIONS.values():
             if impl.checkFile(f):
                 ret = None
@@ -32,7 +34,7 @@ class Profile(object):
                     if impl is lnt.testing.profile.perf.LinuxPerfProfile:
                         ret = impl.deserialize(
                             fd,
-                            objdump=os.getenv('CMAKE_OBJDUMP', 'objdump'),
+                            objdump,
                             binaryCacheRoot=os.getenv('LNT_BINARY_CACHE_ROOT', ''))
                     else:
                         ret = impl.deserialize(fd)

--- a/lnt/tests/test_suite.py
+++ b/lnt/tests/test_suite.py
@@ -15,6 +15,7 @@ import getpass
 
 import datetime
 from collections import defaultdict
+from functools import partial
 import jinja2
 import click
 
@@ -94,7 +95,7 @@ Program;CC;CC_Time;Code_Size;CC_Hash;Exec;Exec_Time;Score
 """
 
 
-def _importProfile(name_filename):
+def _importProfile(objdump, name_filename):
     """_importProfile imports a single profile. It must be at the top level
     (and not within TestSuiteTest) so that multiprocessing can import it
     correctly."""
@@ -692,7 +693,8 @@ class TestSuiteTest(BuiltinTest):
                 "CMAKE_C_FLAGS_RELEASE",
                 "CMAKE_C_FLAGS_RELWITHDEBINFO",
                 "CMAKE_C_COMPILER_TARGET",
-                "CMAKE_CXX_COMPILER_TARGET")]
+                "CMAKE_CXX_COMPILER_TARGET",
+                "CMAKE_OBJDUMP")]
         cmake_vars = {}
         for line in cmake_lah_output.split("\n"):
             for pattern, varname in pattern2var:
@@ -828,7 +830,8 @@ class TestSuiteTest(BuiltinTest):
             TIMEOUT = 800
             try:
                 pool = multiprocessing.Pool()
-                waiter = pool.map_async(_importProfile, profiles_to_import)
+                func = partial(_importProfile, cmake_vars["CMAKE_OBJDUMP"])
+                waiter = pool.map_async(func, profiles_to_import)
                 samples = waiter.get(TIMEOUT)
                 test_samples.extend([sample
                                      for sample in samples


### PR DESCRIPTION
When collecting profiles with `lnt runtest test-suite --use-perf=profile`, it needs a path to objdump to extract the symbols and disassembly. Normally it will try to use `CMAKE_OBJDUMP` from the environment, but AFIAK `lnt` is normally invoked from the command line so no CMake variables are set, so it falls back to just plain old `objdump`.

When running LNT in a cross compilation scenario this leads to a different `objdump` than what CMake uses, which may not support the target. So the profile imports will silently fail to include any code from the binary. 

This fixes it by plumbing through the `CMAKE_OBJDUMP` from the actual llvm-test-suite build. I've left behind the old `os.getenv` as a fallback since `Profile.fromFile` is called from a bunch of other places including `lnt runtest profile`. 

With this patch, using LNT to cross-compile and profile the tests on a remote machine should hopefully "just work"