### PR TITLE
[NFC] Remove stray Python string

### DIFF
--- a/lnt/server/ui/views.py
+++ b/lnt/server/ui/views.py
@@ -1784,7 +1784,6 @@ def rules():
 def log():
     with open(current_app.config['log_file_name'], 'r') as f:
         log_lines = f.readlines()
-    r'2017-07-21 15:02:15,143 ERROR:'
     return render_template("log.html", log_lines=log_lines)
 
 


### PR DESCRIPTION
The string seemingly ended up there by mistake. Its value is simply getting discarded, which is probably why nobody noticed it.