### PR TITLE
Fix various Flake8 issues in the codebase

### DIFF
--- a/lnt/__init__.py
+++ b/lnt/__init__.py
@@ -3,11 +3,4 @@ __email__ = 'daniel@zuster.org'
 __versioninfo__ = (0, 4, 2)
 __version__ = '.'.join(map(str, __versioninfo__)) + '.dev0'
 
-# lnt module is imported from the setup script before modules are installed so
-# modules might not be available.
-try:
-    from typing import Sequence
-except Exception:
-    pass
-
-__all__ = []  # type: Sequence[str]
+__all__ = []

--- a/lnt/formats/__init__.py
+++ b/lnt/formats/__init__.py
@@ -11,9 +11,9 @@ from typing import List, Dict
 from .PlistFormat import format as plist
 from .JSONFormat import format as json
 
-formats = [plist, json]  # type: List[Dict]
-formats_by_name = dict((f['name'], f) for f in formats)  # type: Dict[str, Dict]
-format_names = list(formats_by_name.keys())  # type: List[str]
+formats: List[Dict] = [plist, json]
+formats_by_name: Dict[str, Dict] = dict((f['name'], f) for f in formats)
+format_names: List[str] = list(formats_by_name.keys())
 
 
 def get_format(name):

--- a/lnt/server/__init__.py
+++ b/lnt/server/__init__.py
@@ -1,3 +1,1 @@
-from typing import Sequence
-
-__all__ = []  # type: Sequence[str]
+__all__ = []

--- a/lnt/server/db/__init__.py
+++ b/lnt/server/db/__init__.py
@@ -1,3 +1,1 @@
-from typing import Sequence
-
-__all__ = []  # type: Sequence[str]
+__all__ = []

--- a/lnt/server/db/fieldchange.py
+++ b/lnt/server/db/fieldchange.py
@@ -27,8 +27,7 @@ def post_submit_tasks(session, ts, run_id):
     regenerate_fieldchanges_for_run(session, ts, run_id)
 
 
-def delete_fieldchange(session, ts, change):
-    # type: (Session, TestSuiteDB, TestSuiteDB.FieldChange) -> List[int]
+def delete_fieldchange(session: Session, ts: TestSuiteDB, change: TestSuiteDB.FieldChange) -> List[int]:
     """Delete this field change.  Since it might be attahed to a regression
     via regression indicators, fix those up too.  If this orphans a regression
     delete it as well."""
@@ -64,8 +63,7 @@ def delete_fieldchange(session, ts, change):
 
 
 @timed
-def regenerate_fieldchanges_for_run(session, ts, run_id):
-    # type: (Session, TestSuiteDB, int) -> None
+def regenerate_fieldchanges_for_run(session: Session, ts: TestSuiteDB, run_id: int) -> None:
     """Regenerate the set of FieldChange objects for the given run.
     """
     # Allow for potentially a few different runs, previous_runs, next_runs
@@ -213,8 +211,7 @@ def is_overlaping(fc1, fc2):
            (r1_min < r2_max and r2_min < r1_max)
 
 
-def percent_similar(a, b):
-    # type: (str, str) -> float
+def percent_similar(a: str, b: str) -> float:
     """
     Percent similar: are these strings similar to each other?
     :param a: first string
@@ -225,8 +222,10 @@ def percent_similar(a, b):
 
 
 @timed
-def identify_related_changes(session, ts, fc, active_changes):
-    # type: (Session, TestSuiteDB, TestSuiteDB.FieldChange, List) -> Tuple[bool, List]
+def identify_related_changes(session: Session,
+                             ts: TestSuiteDB,
+                             fc: TestSuiteDB.FieldChange,
+                             active_changes: List) -> Tuple[bool, List]:
     """Can we find a home for this change in some existing regression? If a
     match is found add a regression indicator adding this change to that
     regression, otherwise create a new regression for this change.

--- a/lnt/server/db/migrations/upgrade_2_to_3.py
+++ b/lnt/server/db/migrations/upgrade_2_to_3.py
@@ -46,7 +46,7 @@ def upgrade_testsuite(engine, session, name):
     # Grab Test Suite.
     test_suite = session.query(upgrade_0_to_1.TestSuite).\
                  filter_by(name=name).first()
-    assert(test_suite is not None)
+    assert test_suite is not None
 
     # Add FieldChange to the test suite.
     Base = add_fieldchange(test_suite)

--- a/lnt/server/db/migrations/upgrade_7_to_8.py
+++ b/lnt/server/db/migrations/upgrade_7_to_8.py
@@ -87,7 +87,7 @@ def upgrade_testsuite(engine, session, name):
     # Grab Test Suite.
     test_suite = session.query(upgrade_0_to_1.TestSuite).\
                  filter_by(name=name).first()
-    assert(test_suite is not None)
+    assert test_suite is not None
 
     # Add FieldChange to the test suite.
     Base = add_regressions(test_suite)

--- a/lnt/server/db/rules/__init__.py
+++ b/lnt/server/db/rules/__init__.py
@@ -1,3 +1,1 @@
-from typing import Sequence
-
-__all__ = []  # type: Sequence[str]
+__all__ = []

--- a/lnt/server/db/rules/rule_update_fixed_regressions.py
+++ b/lnt/server/db/rules/rule_update_fixed_regressions.py
@@ -34,8 +34,7 @@ def is_fixed(session, ts, regression):
     return all(fixes)
 
 
-def impacts(session, ts, run_id, regression):
-    # type: (Session, TestSuiteDB, int, TestSuiteDB.Regression) -> bool
+def impacts(session: Session, ts: TestSuiteDB, run_id: int, regression: TestSuiteDB.Regression) -> bool:
     """Does this run have a chance of impacting this regression?
 
     This is just to prevent doing a full comparison, so we don't have
@@ -51,8 +50,7 @@ def impacts(session, ts, run_id, regression):
     return machine_id in regression_machines_set
 
 
-def age_out_oldest_regressions(session, ts, num_to_keep=50):
-    # type: (Session, TestSuiteDB, int) -> int
+def age_out_oldest_regressions(session: Session, ts: TestSuiteDB, num_to_keep: int = 50) -> int:
     """Find the oldest regressions that are still in the detected state,
     and age them out.  This is needed when regressions are not manually
     acknowledged, regression analysis can grow unbounded.
@@ -69,7 +67,7 @@ def age_out_oldest_regressions(session, ts, num_to_keep=50):
         .join(ts.FieldChange) \
         .all()
 
-    regression_newest_change = {}  # type: Dict[int, int]
+    regression_newest_change: Dict[int, int] = {}
     for regression_id, order_id in regression_orders:
         current = regression_newest_change.get(regression_id)
         if current is None or current < order_id:

--- a/lnt/server/db/rules_manager.py
+++ b/lnt/server/db/rules_manager.py
@@ -49,12 +49,12 @@ def load_rules():
 
 
 # Places our rules can hook to.
-HOOKS = {
+HOOKS: Dict['str', List[Callable]] = {
     'post_test_hook': [],
     'post_submission_hook': [],
     'post_regression_create_hook': [],
     'is_useful_change': [],
-}  # type: Dict['str', List[Callable]]
+}
 
 DESCRIPTIONS = {}
 HOOKS_LOADED = False

--- a/lnt/server/db/testsuite.py
+++ b/lnt/server/db/testsuite.py
@@ -167,7 +167,7 @@ class TestSuite(Base):
                 run_fields.append(field)
         ts.run_fields = run_fields
         ts.order_fields = order_fields
-        assert(len(order_fields) > 0)
+        assert len(order_fields) > 0
 
         sample_fields = []
         for index, metric_desc in enumerate(data['metrics']):

--- a/lnt/server/db/util.py
+++ b/lnt/server/db/util.py
@@ -2,7 +2,6 @@ import sqlalchemy
 import sqlalchemy.ext.compiler
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.schema import DDLElement
-from sqlalchemy.ext.compiler import compiles
 from typing import Text, Union
 
 
@@ -16,15 +15,16 @@ class _AddColumn(DDLElement):
         self.column = column
 
 
-@compiles(_AddColumn)
+@sqlalchemy.ext.compiler.compiles(_AddColumn)
 def _visit_add_column(element, compiler, **_):
     return ("ALTER TABLE %s ADD COLUMN %s" %
             (compiler.preparer.quote(element.table_name),
              compiler.get_column_specification(element.column)))
 
 
-def add_column(connectable, table_name, column):
-    # type: (Union[Engine, Connection, None], Text, sqlalchemy.Column) -> None
+def add_column(connectable: Union[Engine, Connection, None],
+               table_name: Text,
+               column: sqlalchemy.Column) -> None:
     """Add this column to the table named `table_name`.
 
     This is a stopgap to a real migration system.  Inspect the Column pass

--- a/lnt/server/reporting/__init__.py
+++ b/lnt/server/reporting/__init__.py
@@ -1,3 +1,1 @@
-from typing import Sequence
-
-__all__ = []  # type: Sequence[str]
+__all__ = []

--- a/lnt/server/ui/__init__.py
+++ b/lnt/server/ui/__init__.py
@@ -1,3 +1,1 @@
-from typing import Sequence
-
-__all__ = []  # type: Sequence[str]
+__all__ = []

--- a/lnt/server/ui/util.py
+++ b/lnt/server/ui/util.py
@@ -279,7 +279,7 @@ def convert_revision(dotted, cache=None):
             return val
 
     dotted_parsed = integral_rex.findall(dotted)
-    val = tuple([int(d) for d in dotted_parsed] or 
+    val = tuple([int(d) for d in dotted_parsed] or
                 [int(hashlib.sha1(dotted.encode("utf-8")).hexdigest(), 16)])
     if cache is not None:
         cache[dotted] = val

--- a/lnt/server/ui/views.py
+++ b/lnt/server/ui/views.py
@@ -954,7 +954,6 @@ def load_geomean_data(field, machine, limit, xaxis_date, revision_cache=None):
 @v4_route("/tableau")
 def v4_tableau():
     """ Tableau WDC."""
-    ts = request.get_testsuite()
     return render_template("v4_tableau.html")
 
 
@@ -1842,8 +1841,7 @@ class MatrixOptions(Form):
     limit = SelectField('Size', choices=MATRIX_LIMITS)
 
 
-def baseline():
-    # type: () -> Optional[testsuitedb.TestSuiteDB.Baseline]
+def baseline() -> Optional[testsuitedb.TestSuiteDB.Baseline]:
     """Get the baseline object from the user's current session baseline value
     or None if one is not defined.
     """

--- a/lnt/testing/__init__.py
+++ b/lnt/testing/__init__.py
@@ -532,7 +532,7 @@ def upgrade_1_to_2(data, ts_name):
     result['format_version'] = '2'
     report_version = data['Run']['Info'].pop('__report_version__', '1')
     # We should not be in upgrade_1_to_2 for other versions
-    assert(report_version == '1')
+    assert report_version == '1'
     tag = data['Run']['Info'].pop('tag', None)
     if tag is not None and tag != ts_name:
         raise ValueError("Importing '%s' data into '%s' testsuite" %
@@ -589,7 +589,7 @@ def upgrade_1_to_2(data, ts_name):
 
         found_metric = False
         for oldname, newname in upgrade.metric_rename.items():
-            assert(oldname.startswith('.'))
+            assert oldname.startswith('.')
             if name_metric.endswith(oldname):
                 name = name_metric[:-len(oldname)]
                 metric = newname

--- a/lnt/testing/util/__init__.py
+++ b/lnt/testing/util/__init__.py
@@ -2,6 +2,4 @@
 Miscellaneous utilities for generating test data.
 """
 
-from typing import Sequence
-
-__all__ = []  # type: Sequence[str]
+__all__ = []

--- a/lnt/tests/test_suite.py
+++ b/lnt/tests/test_suite.py
@@ -450,7 +450,7 @@ class TestSuiteTest(BuiltinTest):
         if self.opts.make:
             defs['CMAKE_MAKE_PROGRAM'] = self.opts.make
         if self.opts.make and (self.opts.make.endswith('ninja') or
-                              self.opts.make.endswith('ninja.exe')):
+                               self.opts.make.endswith('ninja.exe')):
             cmake_flags = ['-G', 'Ninja']
         else:
             cmake_flags = []

--- a/lnt/util/__init__.py
+++ b/lnt/util/__init__.py
@@ -1,6 +1,4 @@
 import logging
-from typing import Sequence
-
 logger = logging.getLogger("lnt.server.ui.app")
 
-__all__ = []  # type: Sequence[str]
+__all__ = []

--- a/lnt/util/wsgi_restart.py
+++ b/lnt/util/wsgi_restart.py
@@ -10,10 +10,10 @@ import queue
 
 _interval = 1.0
 _times = {}
-_files = []  # type: Sequence[Path]
+_files: Sequence[Path] = []
 
 _running = False
-_queue = queue.Queue()  # type: queue.Queue
+_queue: queue.Queue = queue.Queue()
 _lock = threading.Lock()
 
 

--- a/tests/SharedInputs/FakeCompilers/fakecompiler.py
+++ b/tests/SharedInputs/FakeCompilers/fakecompiler.py
@@ -178,6 +178,7 @@ Thread model: posix""", file=sys.stderr)  # noqa
  "%s" "-cc1" "-E" ... more boring stuff here ...""" % (
             g_program,), file=sys.stderr)
 
+
 class GCCDebian(FakeCompiler):
     compiler_name = "gcc-debian"
 
@@ -188,6 +189,7 @@ gcc version 12.2.0 (Debian 12.2.0-14+deb12u1)""", file=sys.stderr)
 
     def print_dumpmachine(self):
         print("x86_64-linux-gnu")
+
 
 class GCCTrunk(FakeCompiler):
     compiler_name = "gcc-trunk"


### PR DESCRIPTION
This patch fixes various Flake8 issues in the codebase to make the Github Actions CI closer to passing.
Issues were related to whitespace, unused imports, bad indentation, etc.

Most missing imports were caused by typing annotations that were only in comments. I upgraded those to actual
type annotations when Tox was complaining, except for a few `__all__` instances: I really don't think there is a large benefit from using strong typing for the `__all__` module variable.