### PR TITLE
Use allowlist_externals instead of whitelist_externals

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,8 @@ envlist = py3
           docs
 
 [testenv]
-whitelist_externals = rm
+allowlist_externals =
+    rm
     make
 
 commands =


### PR DESCRIPTION
Tox's whitelist_externals has been removed in favour of allowlist_externals, which led to `rm` not being considered part of the allow-list, and the tests failing with:

    rm is not allowed, use allowlist_externals to allow it

We already had the right commands in the allow-list, but we were just using the wrong variable name in tox.ini.