### PR TITLE
Bump Sphinx version from 2.0 to 7.x

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ commands =
 [testenv:docs]
 skip_install = true
 deps =
-    sphinx<2.0.0
+    sphinx==7
     sphinx_bootstrap_theme
 
 commands =


### PR DESCRIPTION
This fixes the documentation build. I looked at the documentation output and everything seems fine. Note that the most recent Sphinx version is 8.x, but that requires Python >= 3.10.

Bumping to 7.x resolves CI issues for now without requiring a larger Python update of the whole code base.