### PR TITLE
Bump Python requirement to 3.8 and replace usage of pkg_resources

### DIFF
--- a/lnt/lnttool/main.py
+++ b/lnt/lnttool/main.py
@@ -466,20 +466,17 @@ def _version_check():
     when the version number changes (which may involve changing package
     requirements).
     """
-    import pkg_resources
+    import importlib.metadata
     import lnt
 
     # Get the current distribution.
-    installed_dist = pkg_resources.get_distribution("LNT")
-    if installed_dist.project_name.lower() != lnt.__name__ or \
-       pkg_resources.parse_version(installed_dist.version) != \
-       pkg_resources.parse_version(lnt.__version__):
-        raise SystemExit("""\
-error: installed distribution %s %s is not current (%s %s), you may need to reinstall
-LNT or rerun 'setup.py develop' if using development mode.""" % (
-                         installed_dist.project_name,
-                         installed_dist.version,
-                         lnt.__name__, lnt.__version__))
+    meta = importlib.metadata.metadata("LNT")
+    if meta['Name'].lower() != lnt.__name__ or meta['Version'] != lnt.__version__:
+        installed = "{} {}".format(meta['Name'], meta['Version'])
+        current = "{} {}".format(lnt.__name__, lnt.__version__)
+        raise SystemExit(f"""\
+error: installed distribution {installed} is not current ({current}), you may need to reinstall
+LNT or rerun 'setup.py develop' if using development mode.""")
 
 
 def show_version(ctx, param, value):

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ from sys import platform as _platform
 import sys
 from setuptools import setup, find_packages, Extension
 
-if sys.version_info < (3, 6):
-    raise RuntimeError("Python 3.6 or higher required.")
+if sys.version_info < (3, 8):
+    raise RuntimeError("Python 3.8 or higher required.")
 
 cflags = []
 
@@ -80,7 +80,7 @@ The *LNT* source is available in the llvm-lnt repository:
         'License :: OSI Approved :: Apache-2.0 with LLVM exception',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Software Development :: Testing',
     ],
@@ -138,5 +138,5 @@ The *LNT* source is available in the llvm-lnt repository:
 
     ext_modules=[cPerf],
 
-    python_requires='>=3.6',
+    python_requires='>=3.8',
 )


### PR DESCRIPTION
Before this patch, LNT would use the pkg_resources package to extract metadata about the current installation. However, that package has been deprecated in recent Python versions, which produces a warning. Fixing this either requires switching to the recommended alternative, or pinning the setuptools dependency to a version < 81.

This patch switches to the recommended alternative (importlib.metadata) and bumps the Python requirement to 3.8, which is when importlib.metadata was introduced.

This version bump is fairly gentle and makes us match the Python requirement used by the rest of LLVM (which is IMO overdue for a bump as well), so I think it's reasonable.