### PR TITLE
[tox] Fix a few invalid type annotations

### DIFF
--- a/lnt/server/db/rules/rule_update_fixed_regressions.py
+++ b/lnt/server/db/rules/rule_update_fixed_regressions.py
@@ -34,7 +34,7 @@ def is_fixed(session, ts, regression):
     return all(fixes)
 
 
-def impacts(session: Session, ts: TestSuiteDB, run_id: int, regression: TestSuiteDB.Regression) -> bool:
+def impacts(session: Session, ts: TestSuiteDB, run_id: int, regression) -> bool:
     """Does this run have a chance of impacting this regression?
 
     This is just to prevent doing a full comparison, so we don't have

--- a/lnt/server/ui/views.py
+++ b/lnt/server/ui/views.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import time
+import typing  # noqa: F401
 from collections import namedtuple, defaultdict
 from urllib.parse import urlparse, urljoin
 from io import BytesIO
@@ -20,7 +21,6 @@ from flask import send_file
 from flask_wtf import Form
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
-from typing import Optional
 from wtforms import SelectField, StringField, SubmitField
 from wtforms.validators import DataRequired, Length
 
@@ -36,7 +36,7 @@ import lnt.util
 import lnt.util.ImportData
 import lnt.util.stats
 from lnt.external.stats import stats as ext_stats
-from lnt.server.db import testsuitedb
+from lnt.server.db import testsuitedb  # noqa: F401
 from lnt.server.reporting.analysis import ComparisonResult, calc_geomean
 from lnt.server.ui import util
 from lnt.server.ui.decorators import frontend, db_route, v4_route
@@ -1844,7 +1844,8 @@ class MatrixOptions(Form):
     limit = SelectField('Size', choices=MATRIX_LIMITS)
 
 
-def baseline() -> Optional[testsuitedb.TestSuiteDB.Baseline]:
+def baseline():
+    # type: () -> typing.Optional[testsuitedb.TestSuiteDB.Baseline]
     """Get the baseline object from the user's current session baseline value
     or None if one is not defined.
     """

--- a/tox.ini
+++ b/tox.ini
@@ -24,12 +24,11 @@ deps =
     types-certifi
 
 commands =
-    # Nowhere close to passing yet, but nice to have. The option
-    # --no-incremental is currently needed to suppress warnings about
-    # UpdatedBase when running tests several times. Future versions of
+    # The option --no-incremental is currently needed to suppress warnings
+    # about UpdatedBase when running tests several times. Future versions of
     # mypy should be checked to see if it can be removed and not get
     # warnings after running tox several times.
-    - mypy --no-incremental --junit-xml=junit-{envname}.xml --ignore-missing-imports lnt
+    mypy --no-incremental --junit-xml=junit-{envname}.xml --ignore-missing-imports lnt
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
Some type annotations are using nested types of the TestSuiteDB class. However, these nested types are actually defined in the __init__ method of TestSuiteDB and are hence not accessible as a class member. The easiest fix seems to be to downgrade these type annotations back to comments, at least for now.

In a few other places, add missing annotations to make mypy happy and add `# noqa` to work around flake8 flagging imports as unused (when in reality they are required for mypy annotations).

Finally, make the mypy test non-optional so it shows up as a failure when we break it. We are clearly missing a lot of annotations, but at least we have a basis that we can build upon and avoid regressing.