### PR TITLE
[CI] Update the version of actions used in the CI

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.9
+        python-version: '3.9'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
The PR that added this Github Action was a few years old when we merged it, so it was using versions of actions/checkout and actions/setup-python that are now outdated.