### PR TITLE
[tox] Remove now unused types-setuptools dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ skip_install = true
 deps =
     mypy >= 0.910
     sqlalchemy-stubs
-    types-setuptools
     types-PyYAML
     types-certifi
 


### PR DESCRIPTION
Since we moved away from setuptools, we don't need to install that dependency anymore when running mypy.