### PR TITLE
Unpit lit version from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,6 @@ The *LNT* source is available in the llvm-lnt repository:
         "click==6.7",
         "pyyaml==5.1.2",
         "requests",
-        "lit==0.11.1",
         "certifi"
     ],
 


### PR DESCRIPTION
We install lit via `tox` when we run the tests -- there is no need to install `lit` when we only want to install LNT itself, and even less of a need to pin it to a specific version (which in this case is old and causes a bunch of tests to fail).