### PR TITLE
Add GitHub action to build and push Docker image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,30 @@
+name: Build Docker image
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+    - uses: actions/checkout@v5
+    - name: Log in to the Container registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push Docker image
+      id: push
+      uses: docker/build-push-action@v6
+      with:
+        context: docker
+        push: true
+        tags: ghcr.io/${{github.repository}}:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.10-alpine
 
 RUN apk update \
   && apk add --no-cache --virtual .build-deps git g++ postgresql-dev yaml-dev \

--- a/requirements.server.txt
+++ b/requirements.server.txt
@@ -1,5 +1,5 @@
 # These requirements are what you would install on a production server.
 .
-psycopg2==2.8
+psycopg2==2.9.10
 gunicorn==19.9.0
 progressbar2


### PR DESCRIPTION
To help get the ball rolling with deploying LNT, this adds a GitHub action to build and push images to the GitHub container registry, which is free for public repos. This will push a new image to ghcr.io/llvm-project/llvm-lnt:latest whenever anything is pushed to the main branch.

It also includes a fix for the Dockerfile after the minimum python version was bumped to 3.8 in #48. 3.10 is as high as we can go before we need to upgrade psycopg to 3.x, which in turn requires upgrading sqlalchemy to god knows what. We also need to upgrade psycopg 2.x anyway to get it to build with the newer python bindings.