### PR TITLE
[deps] Bump Pyyaml to 6.0

### DIFF
--- a/requirements.server.txt
+++ b/requirements.server.txt
@@ -3,3 +3,4 @@
 psycopg2==2.8
 gunicorn==19.9.0
 progressbar2
+pyyaml==6.0

--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,7 @@ The *LNT* source is available in the llvm-lnt repository:
         "itsdangerous==0.24",
         "python-gnupg==0.3.7",
         "pytz==2016.10",
+        "pyyaml",
         "WTForms==2.0.2",
         "Flask-WTF==0.12",
         "typing",

--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,6 @@ The *LNT* source is available in the llvm-lnt repository:
         "Flask-WTF==0.12",
         "typing",
         "click==6.7",
-        "pyyaml==5.1.2",
         "requests",
         "certifi"
     ],


### PR DESCRIPTION
This resolves a number of Dependatbot alerts. Also, this moves the pinning down of the depedency from setup.py to requirements.txt, which is apparently best practice.