### PR TITLE
[deps] Bump requirement of Jinja2 to 3.1.6

### DIFF
--- a/requirements.server.txt
+++ b/requirements.server.txt
@@ -2,4 +2,5 @@
 .
 psycopg2==2.8
 gunicorn==19.9.0
+Jinja2==3.1.6
 progressbar2

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ The *LNT* source is available in the llvm-lnt repository:
         "aniso8601==1.2.0",
         "Flask==0.12.2",
         "Flask-RESTful==0.3.4",
-        "Jinja2==2.11.3",
+        "Jinja2",
         "MarkupSafe==1.1.1",
         "SQLAlchemy==1.3.24",
         "Werkzeug==0.15.6",


### PR DESCRIPTION
Also, move the pinning down to requirements.server.txt. This should resolve a few Dependabot alerts.

Supersedes #44