### PR TITLE
Bump minimum Python version to 3.10

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10"]
       fail-fast: false
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ from sys import platform as _platform
 import sys
 from setuptools import setup, find_packages, Extension
 
-if sys.version_info < (3, 8):
-    raise RuntimeError("Python 3.8 or higher required.")
+if sys.version_info < (3, 10):
+    raise RuntimeError("Python 3.10 or higher required.")
 
 cflags = []
 
@@ -80,7 +80,7 @@ The *LNT* source is available in the llvm-lnt repository:
         'License :: OSI Approved :: Apache-2.0 with LLVM exception',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Software Development :: Testing',
     ],
@@ -134,5 +134,5 @@ The *LNT* source is available in the llvm-lnt repository:
 
     ext_modules=[cPerf],
 
-    python_requires='>=3.8',
+    python_requires='>=3.10',
 )


### PR DESCRIPTION
After a recent bump, we documented Python 3.8 as the minimum version. However, we only tested on Python 3.9 and Python 3.10. In reality, I get tons of failures with Python 3.9 and only a small number of failures with Python 3.10.

I think it's makes sense to bump the requirement again if that helps getting to a stable baseline where CI is passing and our dependencies are less ancient. In practice, we'll probably deploy the application using Docker, which means the Python requirement is not critical.