### PR TITLE
Fix test that was using `not` in a shell script

### DIFF
--- a/tests/lnttool/submit.shtest
+++ b/tests/lnttool/submit.shtest
@@ -1,7 +1,4 @@
 #!/bin/bash
-
-# XFAIL: TODO-FIXME
-
 # RUN: rm -rf %t.instance
 # RUN: rm -rf %t.tmp && mkdir -p %t.tmp
 # RUN: python %{shared_inputs}/create_temp_instance.py \
@@ -100,31 +97,31 @@ lnt submit "http://localhost:9091/db_default/submitRun" "${INPUTS}/compile_submi
 rm -f "${OUTPUT_DIR}/submit_errors.txt"
 
 echo "=== compile_submission.json badsuite" >> "${OUTPUT_DIR}/submit_errors.txt"
-not lnt submit "http://localhost:9091/db_default/v4/badsuite/submitRun" "${INPUTS}/compile_submission.json" >> "${OUTPUT_DIR}/submit_errors.txt" 2>&1
+! lnt submit "http://localhost:9091/db_default/v4/badsuite/submitRun" "${INPUTS}/compile_submission.json" >> "${OUTPUT_DIR}/submit_errors.txt" 2>&1
 # CHECK-ERRORS-LABEL: === compile_submission.json badsuite
 # CHECK-ERRORS: error: lnt server: Unknown test suite 'badsuite'!
 
 echo "=== compile_submission.json baddb" >> "${OUTPUT_DIR}/submit_errors.txt"
-not lnt submit "http://localhost:9091/db_baddb/v4/compile/submitRun" "${INPUTS}/compile_submission.json" >> "${OUTPUT_DIR}/submit_errors.txt" 2>&1
+! lnt submit "http://localhost:9091/db_baddb/v4/compile/submitRun" "${INPUTS}/compile_submission.json" >> "${OUTPUT_DIR}/submit_errors.txt" 2>&1
 # CHECK_ERROR-LABEL: === compile_submission.json baddb
 # CHECK-ERRORS: error: lnt server: The page you are looking for does not exist.
 
 echo "=== invalid_submission0.json" >> "${OUTPUT_DIR}/submit_errors.txt"
-not lnt submit "http://localhost:9091/db_default/v4/compile/submitRun" "${INPUTS}/invalid_submission0.json" >> "${OUTPUT_DIR}/submit_errors.txt" 2>&1
+! lnt submit "http://localhost:9091/db_default/v4/compile/submitRun" "${INPUTS}/invalid_submission0.json" >> "${OUTPUT_DIR}/submit_errors.txt" 2>&1
 # CHECK-ERRORS-LABEL: === invalid_submission0.json
 # CHECK-ERRORS: error: lnt server: could not parse input format
 # ...
 # CHECK-ERRORS: ValueError: unable to guess input format for
 
 echo "=== invalid_submission1.json" >> "${OUTPUT_DIR}/submit_errors.txt"
-not lnt submit "http://localhost:9091/db_default/v4/compile/submitRun" "${INPUTS}/invalid_submission1.json" >> "${OUTPUT_DIR}/submit_errors.txt" 2>&1
+! lnt submit "http://localhost:9091/db_default/v4/compile/submitRun" "${INPUTS}/invalid_submission1.json" >> "${OUTPUT_DIR}/submit_errors.txt" 2>&1
 # CHECK-ERRORS-LABEL: === invalid_submission1.json
 # CHECK-ERRORS: error: lnt server: Invalid input format: No 'run' section in submission
 # ...
 # CHECK-ERRORS: ValueError: No 'run' section in submission
 
 echo "=== compile_submission_machine_diff_reject.json" >> "${OUTPUT_DIR}/submit_errors.txt"
-not lnt submit "http://localhost:9091/db_default/v4/compile/submitRun" "${INPUTS}/compile_submission_machine_diff_reject.json" >> "${OUTPUT_DIR}/submit_errors.txt" 2>&1
+! lnt submit "http://localhost:9091/db_default/v4/compile/submitRun" "${INPUTS}/compile_submission_machine_diff_reject.json" >> "${OUTPUT_DIR}/submit_errors.txt" 2>&1
 # CHECK-ERRORS-LABEL: === compile_submission_machine_diff_reject.json
 # CHECK-ERRORS: error: lnt server: import failure: 'hw.activecpu' on machine 'some-compile-suite-machine' changed.
 # ...


### PR DESCRIPTION
`not` is not a known Bash command. Instead, use `!` to negate the result of the `lnt` command being run.