### PR TITLE
Pin Jinja2 to 2.11.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ The *LNT* source is available in the llvm-lnt repository:
         "aniso8601==1.2.0",
         "Flask==0.12.2",
         "Flask-RESTful==0.3.4",
-        "Jinja2",
+        "Jinja2==2.11.3",
         "MarkupSafe==1.1.1",
         "SQLAlchemy==1.3.24",
         "Werkzeug==0.15.6",


### PR DESCRIPTION
8fc27f472c22fe64a838e4e6cc9421996c4fb2c1 pinned MarkupSafe to 1.1.1, which lead to this error on our buildbots that are using Python 3.10 to run the lnt client:
error: MarkupSafe 1.1.1 is installed but MarkupSafe>=2.0 is required by {'Jinja2'}

Jinja2 2.11.3 is the last version that will work with that version of MarkupSafe:
https://github.com/pallets/jinja/blob/2.11.3/setup.py

The 3.x series moved to >= 2.0.0:
https://github.com/pallets/jinja/blob/3.0.0rc1/setup.py