### PR TITLE
Don't override PYTHONPATH in the Lit config

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -27,11 +27,6 @@ config.test_exec_root = 'test_run_tmp'
 
 config.target_triple = None
 
-src_root = os.path.join(config.test_source_root, '..')
-try:
-    config.environment['PYTHONPATH'] = glob.glob('%s/build/lib.*' % src_root)[0]
-except:
-    pass
 # LNT needs a UTF-8 locale when running in Python 3 mode. Rely on the host
 # environment to provide it rather than assume a specific UTF-8 locale is
 # present.
@@ -41,6 +36,7 @@ config.environment['PYTHONDONTWRITEBYTECODE'] = "1"
 config.environment['SUDO_CMD'] = ""
 config.environment['I'] = ""
 
+src_root = os.path.join(config.test_source_root, '..')
 config.substitutions.append(('%src_root', src_root))
 config.substitutions.append(('%{src_root}', src_root))
 config.substitutions.append(('%{shared_inputs}', os.path.join(


### PR DESCRIPTION
The lit.cfg file was overriding PYTHONPATH to use the contents in <PWD>/build if that existed. This means that if you install the package locally with `pip install .` and get that temporary build directory, it will be preferred over the just-built version that gets installed when running `tox`.

Instead, leave PYTHONPATH alone and let it be set by `tox`.