### PR TITLE
Generate JSON reports in format V2 when using `lnt importreport`

### DIFF
--- a/lnt/lnttool/import_report.py
+++ b/lnt/lnttool/import_report.py
@@ -28,24 +28,30 @@ def action_importreport(input, output, suite, order, machine):
     import lnt.testing
     import os
 
-    machine_info = {}
-    run_info = {'tag': suite}
-    run_info['run_order'] = order
-    machine = lnt.testing.Machine(machine,
-                                  machine_info)
+    machine = lnt.testing.Machine(machine, report_version=2)
+
     ctime = os.path.getctime(input.name)
     mtime = os.path.getmtime(input.name)
+    run = lnt.testing.Run(start_time=ctime, end_time=mtime,
+                          info={'llvm_project_revision': order},
+                          report_version=2)
 
-    run = lnt.testing.Run(ctime, mtime, run_info)
-    report = lnt.testing.Report(machine=machine, run=run, tests=[])
-
+    tests = {}  # name => lnt.testing.Test
     for line in input.readlines():
         key, val = line.split()
-        metric = key.split(".")[1]
+        (testname, metric) = key.split(".")
         metric_type = float if metric not in ("hash", "profile") else str
-        test = lnt.testing.TestSamples(suite + "." + key, [val],
-                                       conv_f=metric_type)
 
-        report.tests.extend([test])
+        if testname not in tests:
+            tests[testname] = lnt.testing.Test(testname, [], info={}, report_version=2)
+        test = tests[testname]
 
+        samples = next((s for s in test.samples if s.metric == metric), None)
+        if samples is None:
+            test.samples.append(lnt.testing.MetricSamples(metric, [], report_version=2))
+            samples = test.samples[-1]
+
+        samples.add_samples([val], conv_f=metric_type)
+
+    report = lnt.testing.Report(machine=machine, run=run, tests=list(tests.values()), report_version=2)
     output.write(report.render())

--- a/lnt/testing/__init__.py
+++ b/lnt/testing/__init__.py
@@ -128,7 +128,7 @@ class Machine:
         """
         if self.report_version == 2:
             d = dict(self.info)
-            d['Name'] = self.name
+            d['name'] = self.name
             return d
         else:
             return {'Name': self.name,
@@ -280,7 +280,7 @@ class Test:
         """
         d = dict(self.info)
         d.update([s.render().popitem() for s in self.samples])
-        d['Name'] = self.name
+        d['name'] = self.name
         return d
 
 

--- a/tests/lnttool/Inputs/example_metrics.lnt
+++ b/tests/lnttool/Inputs/example_metrics.lnt
@@ -1,0 +1,5 @@
+foo.execution_time 10
+foo.execution_time 11
+bar.execution_time 20
+foo.hash d7
+bar.profile Xz6/

--- a/tests/lnttool/importreport.shtest
+++ b/tests/lnttool/importreport.shtest
@@ -1,0 +1,30 @@
+# Testing text importing.
+#
+# RUN: lnt importreport --testsuite nts --order 123 --machine foo %S/Inputs/example_metrics.lnt %t.json
+# RUN: filecheck --input-file %t.json %s
+# CHECK:        {
+# CHECK-NEXT:       "format_version": "2",
+# CHECK-NEXT:       "machine": {
+# CHECK-NEXT:           "name": "foo"
+# CHECK-NEXT:       },
+# CHECK-NEXT:       "run": {
+# CHECK-NEXT:           "end_time": "{{.+}}",
+# CHECK-NEXT:           "llvm_project_revision": "123",
+# CHECK-NEXT:           "start_time": "{{.+}}"
+# CHECK-NEXT:       },
+# CHECK-NEXT:       "tests": [
+# CHECK-NEXT:           {
+# CHECK-NEXT:               "execution_time": [
+# CHECK-NEXT:                   10.0,
+# CHECK-NEXT:                   11.0
+# CHECK-NEXT:               ],
+# CHECK-NEXT:               "hash": "d7",
+# CHECK-NEXT:               "name": "foo"
+# CHECK-NEXT:           },
+# CHECK-NEXT:           {
+# CHECK-NEXT:               "execution_time": 20.0,
+# CHECK-NEXT:               "name": "bar",
+# CHECK-NEXT:               "profile": "Xz6/"
+# CHECK-NEXT:           }
+# CHECK-NEXT:       ]
+# CHECK-NEXT:   }

--- a/tests/lnttool/test_importreport.py
+++ b/tests/lnttool/test_importreport.py
@@ -1,8 +1,0 @@
-# Testing text importing.
-#
-# RUN: echo "foo.exec 10" > input
-# RUN: echo "bar.exec 20" >> input
-# RUN: echo "foo.hash d7" >> input
-# RUN: echo "bar.profile Xz6/" >> input
-# RUN: lnt importreport --testsuite nts --order 123 --machine foo input output.json
-# RUN: cat output.json

--- a/tests/testing/TestingTest.py
+++ b/tests/testing/TestingTest.py
@@ -165,12 +165,12 @@ class TestTest(unittest.TestCase):
 
     def test_render(self):
         # Check rendering with no info.
-        d1 = {'Name': 'Test1',
+        d1 = {'name': 'Test1',
               'execution_time': [21.4, 3.2]}
         self.assertDictEqual(self.test_noinfo.render(), d1)
 
         # Check rendering with info.
-        d2 = {'Name': 'Test2',
+        d2 = {'name': 'Test2',
               'execution_time': [21.4, 3.2],
               'nb_files': '2'}
         self.assertDictEqual(self.test_info.render(), d2)
@@ -479,13 +479,13 @@ class TestMachine(unittest.TestCase):
         self.assertDictEqual(self.machine_v1.render(), d2)
 
         # Check v2 rendering with no info.
-        d3 = {'Name': 'Machine3',
+        d3 = {'name': 'Machine3',
               'CPUs': '2'}
         self.assertDictEqual(self.machine_v2.render(), d3)
 
         # Check v2 rendering with info.
         self.machine_v2.info = {}
-        d4 = {'Name': 'Machine3'}
+        d4 = {'name': 'Machine3'}
         self.assertDictEqual(self.machine_v2.render(), d4)
 
 
@@ -662,7 +662,7 @@ class TestReport(unittest.TestCase):
 {
     "format_version": "2",
     "machine": {
-        "Name": "Machine",
+        "name": "Machine",
         "nb_cpus": "2"
     },
     "run": {
@@ -671,11 +671,11 @@ class TestReport(unittest.TestCase):
     },
     "tests": [
         {
-            "Name": "Test",
             "execution_time": [
                 21.4,
                 3.2
             ],
+            "name": "Test",
             "nb_files": "2"
         }
     ]
@@ -687,7 +687,7 @@ class TestReport(unittest.TestCase):
 {
   "format_version": "2",
   "machine": {
-    "Name": "Machine",
+    "name": "Machine",
     "nb_cpus": "2"
   },
   "run": {
@@ -696,11 +696,11 @@ class TestReport(unittest.TestCase):
   },
   "tests": [
     {
-      "Name": "Test",
       "execution_time": [
         21.4,
         3.2
       ],
+      "name": "Test",
       "nb_files": "2"
     }
   ]
@@ -714,7 +714,7 @@ class TestReport(unittest.TestCase):
 {
     "format_version": "2",
     "machine": {
-        "Name": "Machine",
+        "name": "Machine",
         "nb_cpus": "2"
     },
     "run": {
@@ -723,8 +723,8 @@ class TestReport(unittest.TestCase):
     },
     "tests": [
         {
-            "Name": "Test",
             "execution_time": 21.4,
+            "name": "Test",
             "nb_files": "2"
         }
     ]


### PR DESCRIPTION
It seems that a transition towards a new input format had been started a long time ago, however several parts of the codebase don't seem to be producing the latest format yet. This moves `lnt importreport` to the latest format.

As part of the patch, fix capitalization of `Name` for the `Machine` and the `Test` classes, which didn't match the capitalization documented and expected by the rest of the code.