### PR TITLE
Fix several tests failing due to missing CMAKE_OBJDUMP in CMake test fixture

### DIFF
--- a/tests/runtest/Inputs/test-suite-cmake/fake-cmake
+++ b/tests/runtest/Inputs/test-suite-cmake/fake-cmake
@@ -49,6 +49,7 @@ then
   if [[ $CMAKE_C_COMPILER_TARGET != "notfound" ]]; then
     echo CMAKE_C_COMPILER_TARGET:STRING=$CMAKE_C_COMPILER_TARGET
   fi
+  echo CMAKE_OBJDUMP:FILEPATH=objdump
   echo CMAKE_BUILD_TYPE:STRING=RelWithDebInfo
   echo CMAKE_C_FLAGS:STRING=-O0
   echo CMAKE_CXX_FLAGS:STRING=
@@ -67,6 +68,7 @@ else
   echo "Dummy" > CMakeCache.txt
   echo CMAKE_C_COMPILER:FILEPATH=$CMAKE_C_COMPILER >> CMakeCache.txt
   echo CMAKE_CXX_COMPILER:FILEPATH=$CMAKE_CXX_COMPILER >> CMakeCache.txt
+  echo CMAKE_OBJDUMP:FILEPATH=objdump >> CMakeCache.txt
   if [[ $CMAKE_C_COMPILER_TARGET != "notfound" ]]; then
     echo CMAKE_C_COMPILER_TARGET:STRING=$CMAKE_C_COMPILER_TARGET >> CMakeCache.txt
   fi

--- a/tests/runtest/test_suite-compile-only.shtest
+++ b/tests/runtest/test_suite-compile-only.shtest
@@ -1,5 +1,3 @@
-# XFAIL: TODO-FIXME
-
 # Check running with compile only
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \

--- a/tests/runtest/test_suite-perf-events.shtest
+++ b/tests/runtest/test_suite-perf-events.shtest
@@ -1,5 +1,3 @@
-# XFAIL: TODO-FIXME
-
 # Check specifying which linux perf events to measure
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \

--- a/tests/runtest/test_suite-pgo.shtest
+++ b/tests/runtest/test_suite-pgo.shtest
@@ -1,5 +1,3 @@
-# XFAIL: TODO-FIXME
-
 # Check running with PGO
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \

--- a/tests/runtest/test_suite-profile-import.py
+++ b/tests/runtest/test_suite-profile-import.py
@@ -1,5 +1,3 @@
-# XFAIL: TODO-FIXME
-
 # Check importing test-suite profiles into db
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \

--- a/tests/runtest/test_suite-profile.shtest
+++ b/tests/runtest/test_suite-profile.shtest
@@ -1,5 +1,3 @@
-# XFAIL: TODO-FIXME
-
 # Check importing profiles
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \


### PR DESCRIPTION
In #37, test_suite.py started requiring the CMAKE_OBJDUMP variable from the set of CMake variables. Various tests were using a fake CMake test fixture which defines various CMake variables, however CMAKE_OBJDUMP wasn't added in #47, breaking a bunch of tests.

This was probably never noticed because the tests were completely broken back then, I assume they were not being run on a regular basis.