### PR TITLE
Fix broken samples API

### DIFF
--- a/lnt/server/ui/api.py
+++ b/lnt/server/ui/api.py
@@ -438,6 +438,7 @@ class Graph(Resource):
 
         q = session.query(field.column, ts.Order.llvm_project_revision,
                           ts.Run.start_time, ts.Run.id) \
+            .select_from(ts.Sample) \
             .join(ts.Run) \
             .join(ts.Order) \
             .filter(ts.Run.machine_id == machine.id) \

--- a/tests/server/ui/test_api.py
+++ b/tests/server/ui/test_api.py
@@ -1,5 +1,3 @@
-# XFAIL: TODO-FIXME
-
 # Check that the LNT REST JSON API is working.
 # create temporary instance
 # RUN: rm -rf %t.instance


### PR DESCRIPTION
The samples API was performing an invalid SQL query since the ORM update in 5b02472b4d4. This fixes the problem and un-XFAILs the test.