### PR TITLE
Add CI jobs that test on Python 3.11 and 3.12

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,8 @@ The *LNT* source is available in the llvm-lnt repository:
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Software Development :: Testing',
     ],


### PR DESCRIPTION
Since some clients are using more recent versions than 3.10, it makes sense to widen our CI matrix to mirror that.