### PR TITLE
Serialize installation tests

### DIFF
--- a/tests/utils/installation-client.shtest
+++ b/tests/utils/installation-client.shtest
@@ -1,8 +1,0 @@
-# Check that installation using the client requirements works properly.
-#
-# RUN: rm -rf %t.venv
-# RUN: python -m venv %t.venv
-# RUN: cd %{src_root}
-# RUN: %t.venv/bin/python -m pip install -r requirements.client.txt
-# RUN: rm -rf %t.installation
-# RUN: %t.venv/bin/lnt create %t.installation

--- a/tests/utils/installation-server.shtest
+++ b/tests/utils/installation-server.shtest
@@ -1,8 +1,0 @@
-# Check that installation using the server requirements works properly.
-#
-# RUN: rm -rf %t.venv
-# RUN: python -m venv %t.venv
-# RUN: cd %{src_root}
-# RUN: %t.venv/bin/python -m pip install -r requirements.server.txt
-# RUN: rm -rf %t.installation
-# RUN: %t.venv/bin/lnt create %t.installation

--- a/tests/utils/installation.shtest
+++ b/tests/utils/installation.shtest
@@ -1,0 +1,17 @@
+# Check that installation using the client requirements works properly.
+#
+# RUN: rm -rf %t.venv
+# RUN: python -m venv %t.venv
+# RUN: cd %{src_root}
+# RUN: %t.venv/bin/python -m pip install -r requirements.client.txt
+# RUN: rm -rf %t.installation
+# RUN: %t.venv/bin/lnt create %t.installation
+
+# Check that installation using the server requirements works properly.
+#
+# RUN: rm -rf %t.venv
+# RUN: python -m venv %t.venv
+# RUN: cd %{src_root}
+# RUN: %t.venv/bin/python -m pip install -r requirements.server.txt
+# RUN: rm -rf %t.installation
+# RUN: %t.venv/bin/lnt create %t.installation


### PR DESCRIPTION
Due to the way installation of the package works (based on setup.py), it creates temporary content in a build/ directory at the root of the repository. This sometimes causes installation to fail if another installation is happening at the same time, which is problematic for the client/server installation tests.

Until we modernize to a proper pyproject.toml, serialize the installation tests to ensure they don't fail spuriously.