### PR TITLE
Use click.Group instead of MultiCommand

### DIFF
--- a/lnt/lnttool/admin.py
+++ b/lnt/lnttool/admin.py
@@ -341,7 +341,7 @@ testsuite: nts
     sys.stderr.write("Created '%s'\n" % _default_config_filename)
 
 
-class AdminCLI(click.MultiCommand):
+class AdminCLI(click.Group):
     '''Admin subcommands. Put into this class so we can lazily import
     dependencies.'''
     _commands = [

--- a/lnt/lnttool/main.py
+++ b/lnt/lnttool/main.py
@@ -142,7 +142,7 @@ def _print_result_url(results, verbose):
         print("Results available at: no URL available")
 
 
-class RunTestCLI(click.MultiCommand):
+class RunTestCLI(click.Group):
     def list_commands(self, ctx):
         import lnt.tests
         return lnt.tests.get_names()


### PR DESCRIPTION
MultiCommand has been deprecated and it is now an alias to Group, which leads to new mypy warnings when running mypy with Click available in the environment.