### PR TITLE
Drop dependency on python-gnupg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "Flask>=3.1.0",
     "Jinja2>=3.1.0",
     "MarkupSafe>=3.0.0",
-    "python-gnupg>=0.3.7",
     "PyYAML>=6.0.0",
     "requests",
     "SQLAlchemy==1.3.24",

--- a/requirements.client.txt
+++ b/requirements.client.txt
@@ -9,7 +9,6 @@ Flask==3.1.2
 itsdangerous==2.2.0
 Jinja2==3.1.6
 MarkupSafe==3.0.3
-python-gnupg==0.3.7
 pytz==2016.10
 SQLAlchemy==1.3.24
 Werkzeug==3.1.3


### PR DESCRIPTION
According to the git log, this dependency was added for Foreman deployments. However, we shouldn't add dependencies that are only required for DevOps in the requirements of the package itself, since it's perfectly possible to deploy the server using other means as well.

Supersedes #6