### PR TITLE
Bump version to 0.4.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llvm-lnt"
-version = "0.4.2.dev0"
+version = "0.4.3"
 description = "LLVM Nightly Test Infrastructure"
 readme = "README.md"
 license = "LicenseRef-Apache-2.0-with-LLVM-exception"

--- a/tests/server/ui/Inputs/last-run-report.json
+++ b/tests/server/ui/Inputs/last-run-report.json
@@ -1,5 +1,5 @@
 {
-  "generated_by": "LNT Server v0.4.2.dev0",
+  "generated_by": "LNT Server v0.4.3",
   "machine": {
     "id": 4,
     "name": "e105293.local__clang_DEV__x86_64"


### PR DESCRIPTION
There have been enough changes recently that it probably makes sense to bump at least the patch version. As a drive-by, I'm removing the dev0 suffix: this is not a "development" package anymore since it is being used by various clients and for 10 years or so.

This will allow us to exercise the release process on PyPI.