### PR TITLE
Build the Docker image on pushes, tags, and pull requests

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -1,10 +1,8 @@
 name: Build Docker image
 
 on:
-  push:
-    branches: ['main']
-  pull_request:
-    branches: ['main']
+  - push
+  - pull_request
 
 permissions:
   contents: read
@@ -32,6 +30,6 @@ jobs:
       id: push
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
       with:
-        push: ${{ github.event_name == 'push' }}
+        push: ${{ startsWith(github.ref, 'refs/tags/') }} # only push to ghcr.io on tags
         tags: ghcr.io/${{github.repository}}:latest
         context: . # use the current directory as context, as checked out by actions/checkout -- needed for setuptools_scm


### PR DESCRIPTION
Previously, we'd only build the Docker image on pushes and PRs to main. In particular, that excluded tags (even on main). With this patch, build the Docker image all the time, but only push it to ghcr.io when we tag, which is consistent with how we upload to PyPI.