### PR TITLE
Get rid of ambiguous negative boolean options with Click

### DIFF
--- a/lnt/tests/compile.py
+++ b/lnt/tests/compile.py
@@ -997,9 +997,8 @@ class CompileTest(builtintest.BuiltinTest):
               help="Parent directory to build and run tests in",
               type=click.UNPROCESSED, default=None, metavar="PATH")
 #  Test Options
-@click.option("--no-timestamp", "timestamp_build",
-              help="Don't timestamp build directory (for testing)",
-              flag_value=False, default=True)
+@click.option("--timestamp/--no-timestamp", "timestamp_build", default=True, show_default=True,
+              help="Whether to timestamp the build directory (for testing)")
 @click.option("--cc", "cc", type=click.UNPROCESSED, required=True,
               help="Path to the compiler under test")
 @click.option("--cxx", "cxx",
@@ -1033,9 +1032,8 @@ class CompileTest(builtintest.BuiltinTest):
                    "tests in.",
               type=click.UNPROCESSED, default="lnt-compile-suite-src")
 #  Test Selection
-@click.option("--no-memory-profiling", "memory_profiling",
-              help="Disable memory profiling",
-              flag_value=False, default=True)
+@click.option("--memory-profiling/--no-memory-profiling", "memory_profiling", default=True, show_default=True,
+              help="Whether to enable memory profiling")
 @click.option("--multisample", "run_count", metavar="N",
               help="Accumulate test data from multiple runs",
               type=int, default=3)
@@ -1066,10 +1064,8 @@ class CompileTest(builtintest.BuiltinTest):
               metavar="NAME", multiple=True, default=[],
               type=click.Choice(['Debug', 'Release']))
 #  Output Options
-@click.option("--no-machdep-info", "use_machdep_info",
-              help=("Don't put machine (instance) dependent "
-                    "variables in machine info"),
-              flag_value=False, default=True)
+@click.option("--machdep-info/--no-machdep-info", "use_machdep_info", default=True, show_default=True,
+              help="Whether to put machine (instance) dependent variables in machine info")
 @click.option("--machine-name", "machine_name", type=click.UNPROCESSED,
               help="Machine name to use in submission",
               default=platform.uname()[1])

--- a/lnt/tests/nt.py
+++ b/lnt/tests/nt.py
@@ -1851,13 +1851,11 @@ def _tools_check():
 @click.option("-s", "--sandbox", "sandbox_path", required=True,
               help="parent directory to build and run tests in",
               type=click.UNPROCESSED)
-@click.option("--no-timestamp", "timestamp_build", flag_value=False,
-              default=True, show_default=True,
-              help="don't timestamp build directory (for testing)")
-@click.option("--no-configure", "run_configure", flag_value=False,
-              default=True, show_default=True,
-              help="don't run configure if Makefile.config is "
-                   "present (only useful with --no-timestamp)")
+@click.option("--timestamp/--no-timestamp", "timestamp_build", default=False, show_default=True,
+              help="Whether to timestamp the build directory (for testing)")
+@click.option("--configure/--no-configure", "run_configure", default=True, show_default=True,
+              help="Whether to run configure if Makefile.config is present (--no-configure "
+                   "is only useful with --no-timestamp)")
 #  Inputs
 @click.option("--without-llvm", is_flag=True, show_default=True,
               help="don't use any LLVM source or build products")
@@ -1938,23 +1936,20 @@ def _tools_check():
 @click.option("--test-time-stat", type=click.Choice(['user', 'real']),
               default='user', show_default=True,
               help="Set the test timing statistic to gather")
-@click.option("--disable-cxx", "test_cxx", flag_value=False, default=True,
-              show_default=True, help="Disable C++ tests")
-@click.option("--disable-externals", "test_externals", flag_value=False,
-              default=True, show_default=True,
-              help="Disable test suite externals (if configured)")
+@click.option("--enable-cxx/--disable-cxx", "test_cxx", default=True, show_default=True,
+              help="Whether to enable C++ tests")
+@click.option("--enable-externals/--disable-externals", "test_externals", default=True, show_default=True,
+              help="Whether to enable test suite externals (if configured)")
 @click.option("--enable-integrated-as", "test_integrated_as", is_flag=True,
               help="Enable TEST_INTEGRATED_AS tests")
 @click.option("--enable-jit", "test_jit", is_flag=True,
               help="Enable JIT tests")
-@click.option("--disable-llc", "test_llc",
-              help="Disable LLC tests",
-              flag_value=False, show_default=True, default=True)
+@click.option("--enable-llc/--disable-llc", "test_llc", default=True, show_default=True,
+              help="Whether to enable LLC tests")
 @click.option("--enable-llcbeta", "test_llcbeta",
               help="Enable LLCBETA tests", is_flag=True)
-@click.option("--disable-lto", "test_lto",
-              help="Disable use of link-time optimization",
-              flag_value=False, show_default=True, default=True)
+@click.option("--enable-lto/--disable-lto", "test_lto", default=True, show_default=True,
+              help="Whether to enable the use of link-time optimization")
 @click.option("--small", "test_small",
               help="Use smaller test inputs and disable large tests",
               is_flag=True)
@@ -2018,13 +2013,11 @@ def _tools_check():
               help="Accumulate test data from multiple runs",
               type=int, default=None, metavar="N")
 #  Output Options
-@click.option("--no-auto-name", "auto_name",
-              help="Don't automatically derive submission name",
-              flag_value=False, show_default=True, default=True)
-@click.option("--no-machdep-info", "use_machdep_info",
-              help=("Don't put machine (instance) dependent "
-                    "variables with machine info"),
-              flag_value=False, show_default=True, default=True)
+@click.option("--auto-name/--no-auto-name", "auto_name", default=True, show_default=True,
+              help="Whether to automatically derive the submission name")
+@click.option("--machdep-info/--no-machdep-info", "use_machdep_info", default=True, show_default=True,
+              help="Whether to put machine (instance) dependent "
+                   "variables with machine info")
 @click.option("--run-order", "run_order", metavar="STR",
               help="String to use to identify and order this run",
               type=click.UNPROCESSED, default=None)

--- a/lnt/tests/test_suite.py
+++ b/lnt/tests/test_suite.py
@@ -1051,13 +1051,11 @@ class TestSuiteTest(BuiltinTest):
 @click.option("-S", "--sandbox", "sandbox_path", required=True,
               help="Parent directory to build and run tests in",
               type=click.UNPROCESSED, metavar="PATH")
-@click.option("--no-timestamp", "timestamp_build",
-              flag_value=False, default=True,
-              help="Don't timestamp build directory (for testing)")
-@click.option("--no-configure", "run_configure",
-              flag_value=False, default=True,
-              help="Don't run CMake if CMakeCache.txt is present"
-                   " (only useful with --no-timestamp")
+@click.option("--timestamp/--no-timestamp", "timestamp_build", default=True, show_default=True,
+              help="Whether to timestamp the build directory (for testing)")
+@click.option("--configure/--no-configure", "run_configure", default=True, show_default=True,
+              help="Whether to run CMake if CMakeCache.txt is present (--no-configure is only "
+                   "useful with --no-timestamp)")
 # Inputs
 @click.option("--test-suite", "test_suite_root",
               type=click.UNPROCESSED, metavar="PATH",
@@ -1151,9 +1149,8 @@ class TestSuiteTest(BuiltinTest):
 @click.option("--remote-host", metavar="HOST",
               help="Run tests on a remote machine")
 # Output Options
-@click.option("--no-auto-name", "auto_name",
-              help="Don't automatically derive submission name",
-              flag_value=False, default=True)
+@click.option("--auto-name/--no-auto-name", "auto_name", default=True, show_default=True,
+              help="Whether to automatically derive the submission name")
 @click.option("--run-order", "run_order", metavar="STR",
               help="String to use to identify and order this run")
 @click.option("--submit", "submit_url", metavar="URLORPATH",


### PR DESCRIPTION
Click 8.3.x introduced a breaking change with respect to how boolean flags are handled. Indeed, when both a flag_value and a boolean default are passed, the default value will be assumed to determine whether the flag is "passed on the command-line".

This differs from the previous behavior, where the default value was assumed to be the initializer for the flag variable, which is consistent with how non-boolean values are handled.

Since this is quite a confusing mess, stay far from it by making the flags more explicit.

This should make the code base work with versions of Click before 8.3.x and after 8.3.x.