### PR TITLE
Remove .svn directory inclusion from tests

### DIFF
--- a/tests/runtest/nt.py
+++ b/tests/runtest/nt.py
@@ -153,8 +153,7 @@
 # Check submission to a server through url works:
 # RUN: rm -rf %{test_exec_root}/runtest/nt_server_instance
 # RUN: mkdir -p %{test_exec_root}/runtest/nt_server_instance
-# RUN: rsync -av --exclude .svn %S/Inputs/rerun_server_instance/ \
-# RUN:   %{test_exec_root}/runtest/nt_server_instance
+# RUN: rsync -av %S/Inputs/rerun_server_instance/ %{test_exec_root}/runtest/nt_server_instance
 # RUN: %{shared_inputs}/server_wrapper.sh \
 # RUN:   %{test_exec_root}/runtest/nt_server_instance 9089 \
 # RUN:   lnt runtest nt --submit "http://localhost:9089/db_default/submitRun" \
@@ -182,8 +181,7 @@
 # CHECK-SUBMIT-STDERR: Rerunning 0 of 69 benchmarks.
 
 # Check submission to a server through server instance works:
-# RUN: rsync -av --exclude .svn %S/Inputs/rerun_server_instance/ \
-# RUN:   %{test_exec_root}/runtest/nt_server_instance
+# RUN: rsync -av %S/Inputs/rerun_server_instance/ %{test_exec_root}/runtest/nt_server_instance
 # RUN: %{shared_inputs}/server_wrapper.sh \
 # RUN:   %{test_exec_root}/runtest/nt_server_instance 9089 \
 # RUN:   lnt runtest nt --submit "http://localhost:9089/db_default/submitRun" \

--- a/tests/runtest/rerun.py
+++ b/tests/runtest/rerun.py
@@ -5,7 +5,7 @@
 
 # RUN: rm -rf %t.instance
 # RUN: mkdir -p %t.instance
-# RUN: rsync -av --exclude .svn %S/Inputs/rerun_server_instance/ %t.instance
+# RUN: rsync -av %S/Inputs/rerun_server_instance/ %t.instance
 # RUN: rm -f CHECK-STDOUT CHECK-STDOUT2 CHECK-STDERR CHECK-STDERR2
 # RUN: %{shared_inputs}/server_wrapper.sh \
 # RUN:   %t.instance 9090 \


### PR DESCRIPTION
We don't have .svn directories anymore, and for
a pretty long time.