### PR TITLE
Remove --no-incremental when using mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,16 +135,12 @@ skip_install = true
 description = "Typecheck the codebase"
 # TODO: Make it possible to install [.dev] dependencies instead
 deps = [
-    "mypy >= 0.910",
+    "mypy",
     "sqlalchemy-stubs",
     "types-certifi",
     "types-PyYAML",
 ]
-# The option --no-incremental is currently needed to suppress warnings
-# about UpdatedBase when running tests several times. Future versions of
-# mypy should be checked to see if it can be removed and not get
-# warnings after running tox several times.
-commands = [["mypy", "--no-incremental", "--ignore-missing-imports", "lnt"]]
+commands = [["mypy", "--ignore-missing-imports", "lnt"]]
 skip_install = true
 
 [tool.tox.env.docs]


### PR DESCRIPTION
After 10 years, mypy can handle our codebase without that flag.