### PR TITLE
Replace usage of "pipes" with shlex.

### DIFF
--- a/lnt/tests/nt.py
+++ b/lnt/tests/nt.py
@@ -11,7 +11,6 @@ import time
 import traceback
 import urllib.error
 import shlex
-import pipes
 
 try:
     import resource
@@ -1314,7 +1313,7 @@ def _execute_test_again(config, test_name, test_path, test_relative_path,
 
 
 def _unix_quote_args(s):
-    return list(map(pipes.quote, shlex.split(s)))
+    return list(map(shlex.quote, shlex.split(s)))
 
 
 # When set to true, all benchmarks will be rerun.

--- a/lnt/tests/test_suite.py
+++ b/lnt/tests/test_suite.py
@@ -5,7 +5,6 @@ import json
 import os
 import shlex
 import platform
-import pipes
 import sys
 import shutil
 import glob
@@ -865,7 +864,7 @@ class TestSuiteTest(BuiltinTest):
         return report
 
     def _unix_quote_args(self, s):
-        return ' '.join(map(pipes.quote, shlex.split(s)))
+        return ' '.join(map(shlex.quote, shlex.split(s)))
 
     def _cp_artifacts(self, src, dest, patts):
         """Copy artifacts out of the build """


### PR DESCRIPTION
 The pipes module is removed as of python 3.13 and was deprecated in 3.11