### PR TITLE
Add REQUIRES postgres to tests/utils/installation.shtest test

### DIFF
--- a/tests/utils/installation.shtest
+++ b/tests/utils/installation.shtest
@@ -1,3 +1,4 @@
+# REQUIRES: postgres
 # Check that installation using the client requirements works properly.
 #
 # RUN: rm -rf %t.venv


### PR DESCRIPTION
If postgresql isn't installed on the test machine this test fails
during the attempt to build the psycopg2 package with error:
Error: pg_config executable not found.
