### PR TITLE
Update gunicorn to latest version (23.0.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ lnt = "lnt.lnttool:main"
 
 [project.optional-dependencies]
 server = [
-    "gunicorn>=19.9.0",
+    "gunicorn",
     "psycopg2>=2.9.0",
 ]
 dev = [
@@ -66,7 +66,7 @@ dev = [
     "filecheck",
     "Flake8-pyproject",
     "flake8",
-    "gunicorn>=19.9.0",
+    "gunicorn",
     "lit",
     "psycopg2>=2.9.0",
     "tox",

--- a/requirements.server.txt
+++ b/requirements.server.txt
@@ -2,5 +2,5 @@
 # The server has more requirements than the client.
 .
 -r requirements.client.txt
-gunicorn==19.9.0
+gunicorn==23.0.0
 psycopg2==2.9.10


### PR DESCRIPTION
This should resolve some Dependabot complains.
I tested this in the Docker environment with a production server and it appears to work fine.