### PR TITLE
Remove procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: gunicorn app_wrapper:app --log-file - --timeout 300


### PR DESCRIPTION
This must have been used at some point for development since the Procfile was indicating log to stdout, however it's not used anymore. Reduce noise by removing the file.