### PR TITLE
Pull LNT image from ghcr.io in the Docker Compose file

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -1,4 +1,4 @@
-name: Build Docker image
+name: Build LNT Docker image
 
 on:
   - push

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -2,7 +2,7 @@
 # of a container running a Postgres database and a container running a
 # production LNT webserver.
 #
-# In order to build the full service, some secrets are required. They are taken
+# In order to compose the full service, some secrets are required. They are taken
 # as environment variables, which means they can be stored in a file and included
 # via `--env-file <secrets-file>`. These environment variables are:
 #
@@ -18,9 +18,7 @@ name: llvm-lnt
 services:
   webserver:
     container_name: webserver
-    build:
-      context: ../
-      dockerfile: docker/lnt.dockerfile
+    image: ghcr.io/llvm/llvm-lnt:latest
     environment:
       - DB_USER=lntuser
       - DB_HOST=dbserver

--- a/docker/lnt.dockerfile
+++ b/docker/lnt.dockerfile
@@ -1,6 +1,5 @@
 # This Dockerfile defines an image that contains a production LNT server.
-# This image is intended to be built from a Docker Compose file, as it
-# requires additional information passed as environment variables:
+# It requires additional information passed as environment variables:
 #
 #   DB_USER
 #     The username to use for logging into the database.
@@ -17,6 +16,15 @@
 #   AUTH_TOKEN_FILE
 #     File containing the authentication token used to require authentication
 #     to perform destructive actions.
+#
+# It also stores information in the following volumes:
+#
+#   /var/lib/lnt
+#     The actual LNT instance data (schema files, configuration files, etc).
+#
+#   /var/log/lnt
+#     Log files for the instance.
+#
 
 FROM python:3.10-alpine
 


### PR DESCRIPTION
Instead of building the image from scratch from the Docker Compose file, use the image that we automatically build and push to ghcr.io.