### PR TITLE
[docker] Ensure logs from the entrypoint are in /var/log

### DIFF
--- a/docker/docker-entrypoint-log.sh
+++ b/docker/docker-entrypoint-log.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# This is the actual entrypoint script, which ensures that we can find the
+# logs of the real entrypoint script in /var/log.
+docker-entrypoint.sh 2>&1 | tee /var/log/lnt/entrypoint.log

--- a/docker/lnt.dockerfile
+++ b/docker/lnt.dockerfile
@@ -44,6 +44,6 @@ RUN --mount=type=bind,source=.,target=./lnt-source \
 VOLUME /var/lib/lnt /var/log/lnt
 
 # Set up the actual entrypoint that gets run when the container starts.
-COPY docker/docker-entrypoint.sh docker/lnt-wait-db /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+COPY docker/docker-entrypoint.sh docker/docker-entrypoint-log.sh docker/lnt-wait-db /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint-log.sh"]
 EXPOSE 8000


### PR DESCRIPTION
This is useful because it ensures that all of the logs related to LNT are accessible in the same volume, on /var/log/lnt. This is not necessary when running the Docker containers locally, however it's really helpful when running the containers on an EC2 instance where we only have SSH access. Accessing the Docker logs is more difficult in these circumstances.