### PR TITLE
[tox] Don't skip installation when generating the documentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,4 +151,3 @@ deps = [
 ]
 allowlist_externals = ["make"]
 commands = [["make", "-C", "{toxinidir}/docs/", "html"]]
-skip_install = true


### PR DESCRIPTION
Installing the package is required because the documentation build queries information about llvm-lnt through importlib.metadata.