### PR TITLE
Restore original docker-compose DB name

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -39,7 +39,7 @@ services:
     environment:
       - DB_USER=lntuser
       - DB_HOST=dbserver
-      - DB_NAME=lnt.db
+      - DB_NAME=lnt
       - DB_PASSWORD_FILE=/run/secrets/lnt-db-password
       - AUTH_TOKEN_FILE=/run/secrets/lnt-auth-token
     secrets:
@@ -62,7 +62,7 @@ services:
     environment:
       - POSTGRES_PASSWORD_FILE=/run/secrets/lnt-db-password
       - POSTGRES_USER=lntuser
-      - POSTGRES_DB=lnt.db
+      - POSTGRES_DB=lnt
     secrets:
       - lnt-db-password
     volumes:


### PR DESCRIPTION
This was changed in 1b1c1e9 from lnt -> lnt.db, but it broke our Igalia instance which uses this docker compose file.

All the old test results disappeared because we're now reading + writing from a different db.

This changes it back to the original. Not sure if other downstream users were affected
