### PR TITLE
Remove the --no-timestamp option from the test suite

### DIFF
--- a/lnt/tests/compile.py
+++ b/lnt/tests/compile.py
@@ -766,11 +766,7 @@ class CompileTest(builtintest.BuiltinTest):
             print("%s: creating sandbox: %r" % (
                 timestamp(), opts.sandbox_path), file=sys.stderr)
             os.mkdir(opts.sandbox_path)
-        if opts.timestamp_build:
-            fmt_timestamp = timestamp().replace(' ', '_').replace(':', '-')
-            report_name = "test-%s" % (fmt_timestamp)
-        else:
-            report_name = "build"
+        report_name = f"test-{timestamp().replace(' ', '_').replace(':', '-')}"
         g_output_dir = os.path.join(os.path.abspath(opts.sandbox_path),
                                     report_name)
 
@@ -997,8 +993,6 @@ class CompileTest(builtintest.BuiltinTest):
               help="Parent directory to build and run tests in",
               type=click.UNPROCESSED, default=None, metavar="PATH")
 #  Test Options
-@click.option("--timestamp/--no-timestamp", "timestamp_build", default=True, show_default=True,
-              help="Whether to timestamp the build directory (for testing)")
 @click.option("--cc", "cc", type=click.UNPROCESSED, required=True,
               help="Path to the compiler under test")
 @click.option("--cxx", "cxx",

--- a/lnt/tests/test_suite.py
+++ b/lnt/tests/test_suite.py
@@ -342,20 +342,15 @@ class TestSuiteTest(BuiltinTest):
         self.start_time = timestamp()
 
         # Work out where to put our build stuff
-        if opts.build_dir and (opts.exec_mode or opts.build):
-            # With --build-dir, use the specified build directory (for both --build and --exec modes)
-            basedir = opts.build_dir
-        elif opts.exec_interleaved_builds:
+        if opts.exec_interleaved_builds:
             # For exec-interleaved-builds, each build uses its own directory
             # We'll return early from _run_interleaved_builds(), so basedir doesn't matter
             basedir = opts.sandbox_path
+        elif opts.build_dir:
+            # With --build-dir, use the specified build directory
+            basedir = opts.build_dir
         else:
-            # Normal mode: use sandbox/build or sandbox/test-<timestamp>
-            if opts.timestamp_build:
-                ts = self.start_time.replace(' ', '_').replace(':', '-')
-                build_dir_name = "test-%s" % ts
-            else:
-                build_dir_name = "build"
+            build_dir_name = f"test-{self.start_time.replace(' ', '_').replace(':', '-')}"
             basedir = os.path.join(opts.sandbox_path, build_dir_name)
 
         self._base_path = basedir
@@ -1314,11 +1309,8 @@ class TestSuiteTest(BuiltinTest):
 @click.option("-S", "--sandbox", "sandbox_path", required=True,
               help="Parent directory to build and run tests in",
               type=click.UNPROCESSED, metavar="PATH")
-@click.option("--timestamp/--no-timestamp", "timestamp_build", default=True, show_default=True,
-              help="Whether to timestamp the build directory (for testing)")
 @click.option("--configure/--no-configure", "run_configure", default=True, show_default=True,
-              help="Whether to run CMake if CMakeCache.txt is present (--no-configure is only "
-                   "useful with --no-timestamp)")
+              help="Whether to run CMake if CMakeCache.txt is present.")
 # Inputs
 @click.option("--test-suite", "test_suite_root",
               type=click.UNPROCESSED, metavar="PATH",

--- a/tests/runtest/exclude_stat.py
+++ b/tests/runtest/exclude_stat.py
@@ -9,9 +9,10 @@
 # RUN:   --use-make %S/Inputs/test-suite-cmake/fake-make \
 # RUN:   --use-lit %S/Inputs/test-suite-cmake/fake-lit \
 # RUN:   --exclude-stat-from-submission compile \
-# RUN:   --no-timestamp > %t.log 2> %t.err
-# RUN: filecheck --check-prefix CHECK-STDOUT < %t.log %s
-# RUN: filecheck --check-prefix CHECK-REPORT < %t.SANDBOX/build/report.json %s
+# RUN:   --output %t.report.json \
+# RUN:   > %t.log 2> %t.err
+# RUN: filecheck --check-prefix CHECK-STDOUT %s < %t.log
+# RUN: filecheck --check-prefix CHECK-REPORT %s < %t.report.json
 # CHECK-STDOUT: Import succeeded.
 # CHECK-REPORT:     "Name": "nts.{{[^.]+}}.exec"
 # CHECK-REPORT-NOT: "Name": "nts.{{[^.]+}}.compile"

--- a/tests/runtest/test_suite-benchmarking-only.shtest
+++ b/tests/runtest/test_suite-benchmarking-only.shtest
@@ -2,7 +2,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \

--- a/tests/runtest/test_suite-build-dir.shtest
+++ b/tests/runtest/test_suite-build-dir.shtest
@@ -5,7 +5,6 @@
 # RUN: mkdir -p %t.CUSTOM_BUILD
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -25,7 +24,6 @@
 # Test 2: --exec with --build-dir using the custom build location
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --exec \
 # RUN:     --build-dir %t.CUSTOM_BUILD/mybuild \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -43,7 +41,6 @@
 # Test 3: Error case - --exec with --build-dir pointing to non-existent directory should fail
 # RUN: not lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --exec \
 # RUN:     --build-dir %t.NONEXISTENT \
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit \
@@ -56,7 +53,6 @@
 # RUN: mkdir -p %t.UNCONFIGURED
 # RUN: not lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --exec \
 # RUN:     --build-dir %t.UNCONFIGURED \
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit \
@@ -67,7 +63,6 @@
 # Test 5: --exec with --build-dir and --only-test (tuple conversion test)
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --exec \
 # RUN:     --build-dir %t.CUSTOM_BUILD/mybuild \
 # RUN:     --only-test SingleSource \

--- a/tests/runtest/test_suite-c-compiler.shtest
+++ b/tests/runtest/test_suite-c-compiler.shtest
@@ -3,13 +3,13 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cmake-define=CMAKE_C_COMPILER:STRING=%{shared_inputs}/FakeCompilers/clang-r154332 \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
 # RUN:     --use-make %S/Inputs/test-suite-cmake/fake-make \
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit \
-# RUN:     > %t.log 2> %t.err || true
-# RUN: filecheck --check-prefix CHECK-CC-CONFL-CMAKEDEF < %t.SANDBOX/build/report.json %s
+# RUN:     --output %t.report.json \
+# RUN:     || true
+# RUN: filecheck --check-prefix CHECK-CC-CONFL-CMAKEDEF < %t.report.json %s
 # CHECK-CC-CONFL-CMAKEDEF: "run_order": "154332"

--- a/tests/runtest/test_suite-cache.shtest
+++ b/tests/runtest/test_suite-cache.shtest
@@ -4,7 +4,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -36,7 +35,6 @@
 # Check a run of test-suite using a invalid cmake cache
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \

--- a/tests/runtest/test_suite-cc.shtest
+++ b/tests/runtest/test_suite-cc.shtest
@@ -1,12 +1,11 @@
 # Check a missing --cc on the command line
 # RUN: rm -rf %t.SANDBOX
-# RUN: lnt runtest test-suite \
+# RUN: not lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
 # RUN:     --use-make %S/Inputs/test-suite-cmake/fake-make \
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit \
-# RUN:     > %t.log 2> %t.err || true
-# RUN: filecheck  --check-prefix CHECK-MISSING-CC < %t.err %s
+# RUN:     > %t.log 2> %t.err
+# RUN: filecheck --check-prefix CHECK-MISSING-CC %s < %t.err
 # CHECK-MISSING-CC: error: Couldn't find C compiler (). Maybe you should specify --cc?

--- a/tests/runtest/test_suite-cflags0.shtest
+++ b/tests/runtest/test_suite-cflags0.shtest
@@ -2,7 +2,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -10,12 +9,12 @@
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit \
 # RUN:     --cflag '-Wall' \
 # RUN:     > %t.log 2> %t.err
-# RUN: filecheck --check-prefix CHECK-CFLAG1 < %t.err %s
-# CHECK-CFLAG1: Inferred C++ compiler under test
-# CHECK-CFLAG1: CMAKE_C_FLAGS: '-Wall
+# RUN: filecheck %s < %t.err
+# CHECK: Inferred C++ compiler under test
+# CHECK: CMAKE_C_FLAGS: '-Wall
 # Ensure that default c flags for build configurations are made empty to avoid
 # surprises:
-# CHECK-CFLAG1: CMAKE_C_FLAGS_DEBUG: ''
-# CHECK-CFLAG1: CMAKE_C_FLAGS_MINSIZEREL: ''
-# CHECK-CFLAG1: CMAKE_C_FLAGS_RELEASE: ''
-# CHECK-CFLAG1: CMAKE_C_FLAGS_RELWITHDEBINFO: ''
+# CHECK: CMAKE_C_FLAGS_DEBUG: ''
+# CHECK: CMAKE_C_FLAGS_MINSIZEREL: ''
+# CHECK: CMAKE_C_FLAGS_RELEASE: ''
+# CHECK: CMAKE_C_FLAGS_RELWITHDEBINFO: ''

--- a/tests/runtest/test_suite-cflags1.shtest
+++ b/tests/runtest/test_suite-cflags1.shtest
@@ -2,7 +2,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -12,6 +11,6 @@
 # RUN:     --cflag '-mfloat-abi=hard' \
 # RUN:     --cflag '-O3' \
 # RUN:     > %t.log 2> %t.err
-# RUN: filecheck --check-prefix CHECK-CFLAG2 < %t.err %s
-# CHECK-CFLAG2: Inferred C++ compiler under test
-# CHECK-CFLAG2: CMAKE_C_FLAGS: '-Wall -mfloat-abi=hard -O3
+# RUN: filecheck %s < %t.err
+# CHECK: Inferred C++ compiler under test
+# CHECK: CMAKE_C_FLAGS: '-Wall -mfloat-abi=hard -O3

--- a/tests/runtest/test_suite-cflags2.shtest
+++ b/tests/runtest/test_suite-cflags2.shtest
@@ -2,7 +2,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -10,6 +9,6 @@
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit \
 # RUN:     --cflags '-Wall -mfloat-abi=hard -O3' \
 # RUN:     > %t.log 2> %t.err
-# RUN: filecheck --check-prefix CHECK-CFLAG3 < %t.err %s
-# CHECK-CFLAG3: Inferred C++ compiler under test
-# CHECK-CFLAG3: CMAKE_C_FLAGS: '-Wall -mfloat-abi=hard -O3
+# RUN: filecheck %s < %t.err
+# CHECK: Inferred C++ compiler under test
+# CHECK: CMAKE_C_FLAGS: '-Wall -mfloat-abi=hard -O3

--- a/tests/runtest/test_suite-cflags3.shtest
+++ b/tests/runtest/test_suite-cflags3.shtest
@@ -2,7 +2,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -10,6 +9,6 @@
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit \
 # RUN:     --cflags "-Wall -test=escaped\ space -some-option='stay with me' -O3" \
 # RUN:     > %t.log 2> %t.err
-# RUN: filecheck --check-prefix CHECK-CFLAG4 < %t.err %s
-# CHECK-CFLAG4: Inferred C++ compiler under test
-# CHECK-CFLAG4: CMAKE_C_FLAGS: '-Wall '-test=escaped space' '-some-option=stay with me' -O3
+# RUN: filecheck < %t.err %s
+# CHECK: Inferred C++ compiler under test
+# CHECK: CMAKE_C_FLAGS: '-Wall '-test=escaped space' '-some-option=stay with me' -O3

--- a/tests/runtest/test_suite-cflags4.shtest
+++ b/tests/runtest/test_suite-cflags4.shtest
@@ -2,7 +2,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -12,6 +11,6 @@
 # RUN:   --cflag '-Weverything' \
 # RUN:   --cflags '-Wall -test=escaped\ space -some-option="stay with me" -O3' \
 # RUN:     > %t.log 2> %t.err
-# RUN: filecheck --check-prefix CHECK-CFLAG5 < %t.err %s
-# CHECK-CFLAG5: Inferred C++ compiler under test
-# CHECK-CFLAG5: CMAKE_C_FLAGS: '--target=armv7a-none-eabi -Weverything -Wall '-test=escaped space' '-some-option=stay with me' -O3
+# RUN: filecheck %s < %t.err
+# CHECK: Inferred C++ compiler under test
+# CHECK: CMAKE_C_FLAGS: '--target=armv7a-none-eabi -Weverything -Wall '-test=escaped space' '-some-option=stay with me' -O3

--- a/tests/runtest/test_suite-compile-only.shtest
+++ b/tests/runtest/test_suite-compile-only.shtest
@@ -2,7 +2,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -10,6 +9,6 @@
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit-profile \
 # RUN:     --verbose \
 # RUN:     --only-compile \
-# RUN:     > %t.pgo.log 2> %t.compile-only.err
-# RUN: filecheck --check-prefix CHECK-CO < %t.compile-only.err %s
-# CHECK-CO: TEST_SUITE_RUN_BENCHMARKS: 'Off'
+# RUN:     > %t.log 2> %t.err
+# RUN: filecheck %s < %t.err
+# CHECK: TEST_SUITE_RUN_BENCHMARKS: 'Off'

--- a/tests/runtest/test_suite-cross.shtest
+++ b/tests/runtest/test_suite-cross.shtest
@@ -3,13 +3,13 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cmake-define=CMAKE_C_COMPILER_TARGET:STRING=targetarch-linux-gnu \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
 # RUN:     --use-make %S/Inputs/test-suite-cmake/fake-make \
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit \
-# RUN:     > %t.log 2> %t.err || true
-# RUN: filecheck --check-prefix CHECK-CROSS-TARGET < %t.SANDBOX/build/report.json %s
-# CHECK-CROSS-TARGET: "cc_target": "targetarch-linux-gnu"
+# RUN:     --output %t.report.json \
+# RUN:     || true
+# RUN: filecheck %s < %t.report.json
+# CHECK: "cc_target": "targetarch-linux-gnu"

--- a/tests/runtest/test_suite-drop-exec.shtest
+++ b/tests/runtest/test_suite-drop-exec.shtest
@@ -4,7 +4,6 @@
 # Test 1: --drop-exec without --exec-multisample should fail
 # RUN: not lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX-ERR1 \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -18,7 +17,6 @@
 # Test 2: --drop-exec with --only-compile should fail
 # RUN: not lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX-ERR2 \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -33,7 +31,6 @@
 # Test 3: --drop-exec with --build should fail
 # RUN: not lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX-ERR3 \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -48,7 +45,6 @@
 # Test 4: --drop-exec dropping all samples should fail
 # RUN: not lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX-ERR4 \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -64,7 +60,6 @@
 # RUN: rm -rf %t.SANDBOX-DROP1
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX-DROP1 \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -82,7 +77,6 @@
 # RUN: rm -rf %t.SANDBOX-DROP2
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX-DROP2 \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -101,20 +95,18 @@
 # RUN: rm -rf %t.SANDBOX-BUILD-PREBUILT
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX-BUILD-PREBUILT \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
 # RUN:     --use-make %S/Inputs/test-suite-cmake/fake-make \
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit \
 # RUN:     --build \
-# RUN:     > %t.build-prebuilt.log 2> %t.build-prebuilt.err
+# RUN:     --build-dir %t.SANDBOX-BUILD-PREBUILT/build
 
 # Now test prebuilt with --drop-exec
 # RUN: rm -rf %t.SANDBOX-PREBUILT-TEST
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX-PREBUILT-TEST \
-# RUN:     --no-timestamp \
 # RUN:     --exec \
 # RUN:     --build-dir %t.SANDBOX-BUILD-PREBUILT/build \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \

--- a/tests/runtest/test_suite-fail-compile.shtest
+++ b/tests/runtest/test_suite-fail-compile.shtest
@@ -1,15 +1,15 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --no-configure \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
 # RUN:     --use-make %S/Inputs/test-suite-cmake/fake-make \
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit-fails-compile \
-# RUN:     --run-order=123 > %t.log 2> %t.err
-# RUN: filecheck --check-prefix CHECK-RESULTS-FAIL-COMPILE < %t.SANDBOX/build/report.json %s
+# RUN:     --output %t.report.json \
+# RUN:     --run-order=123
+# RUN: filecheck --check-prefix CHECK-RESULTS-FAIL-COMPILE < %t.report.json %s
 # CHECK-RESULTS-FAIL-COMPILE: "no_errors": "False"
 # CHECK-RESULTS-FAIL-COMPILE: "run_order": "123"
 # CHECK-RESULTS-FAIL-COMPILE: "Name": "nts.bar.compile.status"

--- a/tests/runtest/test_suite-fail-exec.shtest
+++ b/tests/runtest/test_suite-fail-exec.shtest
@@ -1,15 +1,15 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --no-configure \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
 # RUN:     --use-make %S/Inputs/test-suite-cmake/fake-make \
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit-fails-exec \
-# RUN:     --run-order=123 > %t.log 2> %t.err
-# RUN: filecheck --check-prefix CHECK-RESULTS-FAIL-EXEC < %t.SANDBOX/build/report.json %s
+# RUN:     --output %t.report.json \
+# RUN:     --run-order=123
+# RUN: filecheck --check-prefix CHECK-RESULTS-FAIL-EXEC < %t.report.json %s
 # CHECK-RESULTS-FAIL-EXEC: "no_errors": "False"
 # CHECK-RESULTS-FAIL-EXEC: "run_order": "123"
 # CHECK-RESULTS-FAIL-EXEC: "Name": "nts.baz.exec.status"

--- a/tests/runtest/test_suite-interleaved-builds.shtest
+++ b/tests/runtest/test_suite-interleaved-builds.shtest
@@ -4,13 +4,13 @@
 # RUN: rm -rf %t.SANDBOX-A %t.SANDBOX-B %t.SANDBOX-RESULTS
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX-A \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
 # RUN:     --use-make %S/Inputs/test-suite-cmake/fake-make \
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit \
 # RUN:     --build \
+# RUN:     --build-dir %t.SANDBOX-A/build \
 # RUN:     > %t.build-a.log 2> %t.build-a.err
 # RUN: filecheck --check-prefix CHECK-BUILD < %t.build-a.err %s
 # CHECK-BUILD: Building tests (--build mode)...
@@ -20,19 +20,17 @@
 # Test 2: Build a second sandbox
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX-B \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
 # RUN:     --use-make %S/Inputs/test-suite-cmake/fake-make \
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit \
 # RUN:     --build \
-# RUN:     > %t.build-b.log 2> %t.build-b.err
+# RUN:     --build-dir %t.SANDBOX-B/build
 
 # Test 3: Exec prebuilt with single build
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX-RESULTS \
-# RUN:     --no-timestamp \
 # RUN:     --exec \
 # RUN:     --build-dir %t.SANDBOX-A/build \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -48,7 +46,6 @@
 # RUN: rm -rf %t.SANDBOX-RESULTS
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX-RESULTS \
-# RUN:     --no-timestamp \
 # RUN:     --exec-interleaved-builds %t.SANDBOX-A/build,%t.SANDBOX-B/build \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit \
@@ -91,7 +88,6 @@
 # Test 6: Error case - --build with --exec should fail
 # RUN: not lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX-ERR \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --build \
@@ -103,7 +99,6 @@
 # Test 7: Error case - --exec without --build-dir or --exec-interleaved-builds should fail
 # RUN: not lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX-ERR2 \
-# RUN:     --no-timestamp \
 # RUN:     --exec \
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit \
 # RUN:     > %t.err2.log 2> %t.err2.err

--- a/tests/runtest/test_suite-machine-name.shtest
+++ b/tests/runtest/test_suite-machine-name.shtest
@@ -2,7 +2,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --no-configure \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \

--- a/tests/runtest/test_suite-metrics.shtest
+++ b/tests/runtest/test_suite-metrics.shtest
@@ -3,16 +3,14 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
 # RUN:     --use-make %S/Inputs/test-suite-cmake/fake-make \
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit \
-# RUN:     --verbose \
-# RUN:     > %t.log 2> %t.err
-# RUN: filecheck --check-prefix CHECK-METRICS < %t.SANDBOX/build/report.json %s
-# RUN: filecheck --check-prefix CHECK-METRICS2 < %t.SANDBOX/build/report.json %s
+# RUN:     --output %t.report.json
+# RUN: filecheck --check-prefix CHECK-METRICS < %t.report.json %s
+# RUN: filecheck --check-prefix CHECK-METRICS2 < %t.report.json %s
 # CHECK-METRICS-DAG: foo.exec
 # CHECK-METRICS-DAG: foo.compile
 # CHECK-METRICS-DAG: foo.score

--- a/tests/runtest/test_suite-only-test.shtest
+++ b/tests/runtest/test_suite-only-test.shtest
@@ -2,7 +2,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \

--- a/tests/runtest/test_suite-perf-events.shtest
+++ b/tests/runtest/test_suite-perf-events.shtest
@@ -2,7 +2,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \

--- a/tests/runtest/test_suite-pgo.shtest
+++ b/tests/runtest/test_suite-pgo.shtest
@@ -2,7 +2,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -20,7 +19,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \

--- a/tests/runtest/test_suite-profile-import.py
+++ b/tests/runtest/test_suite-profile-import.py
@@ -2,7 +2,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -11,11 +10,10 @@
 # RUN:     --use-perf=all \
 # RUN:     -j2 \
 # RUN:     --verbose \
-# RUN:     > %t.log 2> %t.err
+# RUN:     --output %t.report.json
 # RUN: rm -rf %t.DB
-# RUN: lnt create %t.DB >> %t.log 2>> %t.err
-# RUN: lnt import %t.DB %t.SANDBOX/build/report.json \
-# RUN:   --show-sample-count >> %t.log 2>> %t.err
+# RUN: lnt create %t.DB
+# RUN: lnt import %t.DB %t.report.json --show-sample-count
 # RUN: python %s %t.DB
 
 import sys

--- a/tests/runtest/test_suite-profile.shtest
+++ b/tests/runtest/test_suite-profile.shtest
@@ -2,7 +2,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \

--- a/tests/runtest/test_suite-run-order.shtest
+++ b/tests/runtest/test_suite-run-order.shtest
@@ -2,13 +2,13 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --no-configure \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
 # RUN:     --use-make %S/Inputs/test-suite-cmake/fake-make \
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit \
-# RUN:     --run-order=123 > %t.log 2> %t.err
-# RUN: filecheck --check-prefix CHECK-RESULTS < %t.SANDBOX/build/report.json %s
+# RUN:     --output %t.report.json \
+# RUN:     --run-order=123
+# RUN: filecheck --check-prefix CHECK-RESULTS < %t.report.json %s
 # CHECK-RESULTS: "run_order": "123"

--- a/tests/runtest/test_suite-run-under.shtest
+++ b/tests/runtest/test_suite-run-under.shtest
@@ -2,7 +2,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: not lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --no-configure \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
@@ -18,7 +17,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -33,7 +31,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \

--- a/tests/runtest/test_suite-use-perf.shtest
+++ b/tests/runtest/test_suite-use-perf.shtest
@@ -2,7 +2,6 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \

--- a/tests/runtest/test_suite.shtest
+++ b/tests/runtest/test_suite.shtest
@@ -2,7 +2,7 @@
 # RUN: rm -rf %t.SANDBOX
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
+# RUN:     --build-dir %t.SANDBOX/build \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -10,8 +10,8 @@
 # RUN:     --use-lit %S/Inputs/test-suite-cmake/fake-lit \
 # RUN:     --output %t.report \
 # RUN:     > %t.out 2> %t.err
-# RUN: lnt checkformat %t.report > %t.checkformat
 # RUN: filecheck  --check-prefix CHECK-BASIC < %t.err %s
+# RUN: lnt checkformat %t.report > %t.checkformat
 # RUN: filecheck  --check-prefix CHECK-REPORT < %t.SANDBOX/build/report.json %s
 # RUN: filecheck  --check-prefix CHECK-XML < %t.SANDBOX/build/test-results.xunit.xml %s
 # RUN: filecheck  --check-prefix CHECK-CSV < %t.SANDBOX/build/test-results.csv %s
@@ -51,7 +51,7 @@
 # Use the same sandbox again with --no-configure
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
+# RUN:     --build-dir %t.SANDBOX/build \
 # RUN:     --no-configure \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
@@ -66,7 +66,7 @@
 # RUN: rm -rf %t.SANDBOX2
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX2 \
-# RUN:     --no-timestamp \
+# RUN:     --build-dir %t.SANDBOX2/build \
 # RUN:     --no-configure \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \

--- a/tests/runtest/test_suite_diagnose.shtest
+++ b/tests/runtest/test_suite_diagnose.shtest
@@ -7,7 +7,6 @@
 # Check --diagnose requires --only-test
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-cmake \
@@ -21,7 +20,6 @@
 # Check a basic test-suite run.
 # RUN: lnt runtest test-suite \
 # RUN:     --sandbox %t.SANDBOX \
-# RUN:     --no-timestamp \
 # RUN:     --test-suite %S/Inputs/test-suite-cmake \
 # RUN:     --cc %{shared_inputs}/FakeCompilers/clang-r154331 \
 # RUN:     --use-cmake %S/Inputs/test-suite-cmake/fake-diagnose-cmake \


### PR DESCRIPTION
--no-timestamp was only useful for testing purposes. However, now that we have the --build-dir option, we can use that to specify a stable build directory from the tests. Also remove several places where --no-timestamp was unnecessary since we didn't need a stable build directory.