### PR TITLE
[docker] Avoid breaking the config file when the token contains arbitrary characters

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -14,7 +14,11 @@ if [ ! -e /var/lib/lnt/instance/lnt.cfg ]; then
         --tmp-dir /tmp/lnt              \
         --db-dir "${DB_PATH}"           \
         --default-db "${DB_NAME}"
-    sed -i "s/# \(api_auth_token =\).*/\1 '${token}'/" /var/lib/lnt/instance/lnt.cfg
+    if [[ "${token}" == *"'"* ]]; then
+        echo "Invalid API auth token containing single quote ('): that character is used as a delimiter in the config file"
+        exit 1
+    fi
+    echo "api_auth_token = '${token}'" >> /var/lib/lnt/instance/lnt.cfg
 fi
 
 # Run the server under gunicorn.


### PR DESCRIPTION
Instead of providing the token to sed, just cat the necessary line into the config file, which avoids problems if the token contains special characters. Also, detect the special case where the token contains ', in which case it would lead to an invalid config file.