### PR TITLE
Fix group_by call when graphing geomean

### DIFF
--- a/lnt/server/ui/views.py
+++ b/lnt/server/ui/views.py
@@ -948,7 +948,7 @@ def load_geomean_data(field, machine, limit, xaxis_date, revision_cache=None):
                     .join(ts.Run).join(ts.Order).join(ts.Test) \
                     .filter(ts.Run.machine_id == machine.id) \
                     .filter(field.column.isnot(None)) \
-                    .group_by(ts.Order.llvm_project_revision, ts.Test)
+                    .group_by(ts.Order, ts.Test)
 
     if limit:
         values = values.limit(limit)


### PR DESCRIPTION
This went undetected since we don't run the tests against PostgreSQL, but this is a hard error when running in production.

Fixes #121