### PR TITLE
Add with_temporary_instance.py that creates an empty instance

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -18,7 +18,8 @@ config.test_format = lit.formats.ShTest()
 config.suffixes = ['.py', '.shtest']
 
 # excludes: A list of individual files to exclude.
-config.excludes = ['__init__.py', 'Inputs', 'SharedInputs']
+config.excludes = ['__init__.py', 'Inputs', 'SharedInputs',
+                   'with_temporary_instance.py']
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(os.path.abspath(__file__))

--- a/tests/lnttool/admin/test-suite/add.shtest
+++ b/tests/lnttool/admin/test-suite/add.shtest
@@ -1,8 +1,8 @@
 # RUN: rm -rf %t.instance
 # RUN: rm -rf %t.tmp && mkdir -p %t.tmp
-# RUN: python %{shared_inputs}/create_temp_instance.py \
-# RUN:   %s %{shared_inputs}/SmallInstance %t.instance
-# RUN: %{shared_inputs}/server_wrapper.sh %t.instance 9095 /bin/sh %s %t.tmp %{shared_inputs}
+# RUN: %{utils}/with_postgres.sh %t.pg.log \
+# RUN:     %{utils}/with_temporary_instance.py %t.instance \
+# RUN:         -- %{shared_inputs}/server_wrapper.sh %t.instance 9095 /bin/sh %s %t.tmp %{shared_inputs}
 
 set -eux
 DIR="$1"

--- a/tests/server/api/schema/post.py
+++ b/tests/server/api/schema/post.py
@@ -1,11 +1,9 @@
 # This test checks the /schema POST API that allows creating a new schema.
 
 # RUN: rm -rf %t.instance
-# RUN: python %{shared_inputs}/create_temp_instance.py \
-# RUN:     %s %{shared_inputs}/SmallInstance \
-# RUN:     %t.instance %S/../../ui/Inputs/V4Pages_extra_records.sql
-#
-# RUN: python %s %t.instance
+# RUN: %{utils}/with_postgres.sh %t.pg.log \
+# RUN:     %{utils}/with_temporary_instance.py %t.instance \
+# RUN:         -- python %s %t.instance
 # END.
 
 import json

--- a/tests/server/ui/change_processing.py
+++ b/tests/server/ui/change_processing.py
@@ -1,11 +1,5 @@
 # Check that the LNT REST JSON API is working.
-# create temporary instance
-# RUN: rm -rf %t.instance
-# RUN: python %{shared_inputs}/create_temp_instance.py \
-# RUN:     %s %{shared_inputs}/SmallInstance \
-# RUN:     %t.instance %S/Inputs/V4Pages_extra_records.sql
-#
-# RUN: python %s %t.instance
+# RUN: python %s
 
 import datetime
 import logging

--- a/tests/server/ui/test_system_info.py
+++ b/tests/server/ui/test_system_info.py
@@ -1,10 +1,7 @@
-# create temporary instance
 # RUN: rm -rf %t.instance
-# RUN: python %{shared_inputs}/create_temp_instance.py \
-# RUN:     %s %{shared_inputs}/SmallInstance \
-# RUN:     %t.instance %S/Inputs/V4Pages_extra_records.sql
-#
-# RUN: python %s %t.instance %{tidylib}
+# RUN: %{utils}/with_postgres.sh %t.pg.log \
+# RUN:     %{utils}/with_temporary_instance.py %t.instance \
+# RUN:         -- python %s %t.instance %{tidylib}
 
 import unittest
 import logging

--- a/tests/utils/with_temporary_instance.py
+++ b/tests/utils/with_temporary_instance.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+"""Create a temporary LNT instance backed by PostgreSQL and optionally import
+JSON report files, then exec the given command.
+
+Expects LNT_TEST_DB_URI and LNT_TEST_DB_NAME environment variables
+(set by with_postgres.sh).
+"""
+
+import argparse
+import glob
+import json
+import os
+import subprocess
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Create a temporary LNT instance backed by PostgreSQL and optionally import "
+                    "JSON report files, then exec the given command. Expects LNT_TEST_DB_URI and "
+                    "LNT_TEST_DB_NAME environment variables (set by with_postgres.sh).",
+        usage="%(prog)s DEST_DIR [DATA_DIR ...] -- COMMAND [ARGS ...]",
+    )
+    parser.add_argument('dest_dir', metavar='DEST_DIR',
+                        help='directory where the LNT instance will be created')
+    parser.add_argument('data_dirs', metavar='DATA_DIR', nargs='*',
+                        help='directories containing JSON report files to import')
+
+    # Split at '--' to separate instance arguments from the command to exec.
+    argv = sys.argv[1:]
+    if '--' not in argv:
+        parser.error("expected '--' to separate instance arguments from COMMAND")
+    sep = argv.index('--')
+    command = argv[sep + 1:]
+    args = parser.parse_args(argv[:sep])
+
+    if not command:
+        parser.error("COMMAND is required after '--'")
+
+    dest_dir = os.path.abspath(args.dest_dir)
+    data_dirs = args.data_dirs
+
+    db_uri = os.environ['LNT_TEST_DB_URI']
+    db_name = os.environ['LNT_TEST_DB_NAME']
+
+    # 1. Create the LNT instance.
+    subprocess.check_call(['lnt', 'create', dest_dir, '--db-dir', db_uri, '--default-db', db_name])
+
+    # 2. Symlink schema YAML files into the instance.
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    schemas_src = os.path.join(script_dir, '..', '..', 'schemas')
+    schemas_dst = os.path.join(dest_dir, 'schemas')
+    for schema in ('nts.yaml', 'compile.yaml'):
+        os.symlink(
+            os.path.join(schemas_src, schema),
+            os.path.join(schemas_dst, schema),
+        )
+
+    # 3. Append test configuration to lnt.cfg.
+    cfg_path = os.path.join(dest_dir, 'lnt.cfg')
+    with open(cfg_path, 'a') as f:
+        f.write("\napi_auth_token = \"test_token\"\n")
+        f.write("zorgURL = 'http://localhost/perf'\n")
+
+    # 4. Import JSON report files from each DATA_DIR.
+    for data_dir in data_dirs:
+        json_files = sorted(glob.glob(os.path.join(data_dir, '*.json')))
+        for json_file in json_files:
+            with open(json_file) as f:
+                data = json.load(f)
+            suite = data.get('schema', 'nts')
+            subprocess.check_call(['lnt', 'import', '-s', suite, dest_dir, json_file])
+
+    # 5. Exec the wrapped command.
+    os.execvp(command[0], command)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Also, migrate a few tests to a combination of with_postgres.sh and the new script for setting up an instance. This migrates the easy tests to use a Postgres database instead of sqlite.

Assisted-by: Claude