### PR TITLE
[NFC] Remove unused substitution in lit.cfg

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -37,7 +37,6 @@ config.environment['SUDO_CMD'] = ""
 config.environment['I'] = ""
 
 src_root = os.path.join(config.test_source_root, '..')
-config.substitutions.append(('%src_root', src_root))
 config.substitutions.append(('%{src_root}', src_root))
 config.substitutions.append(('%{shared_inputs}', os.path.join(config.test_source_root, 'SharedInputs')))
 config.substitutions.append(('%{utils}', os.path.join(config.test_source_root, 'utils')))


### PR DESCRIPTION
We already have the %{src_root} substitution instead.