### PR TITLE
Fix concurrent database initialization races

### DIFF
--- a/lnt/server/db/v4db.py
+++ b/lnt/server/db/v4db.py
@@ -69,14 +69,29 @@ class V4DB(object):
         self.engine = sqlalchemy.create_engine(path,
                                                connect_args=connect_args)
 
-        # Update the database to the current version, if necessary. Only check
-        # this once per path.
-        lnt.server.db.migrate.update(self.engine)
+        # On Postgres, use an advisory lock to prevent multiple gunicorn
+        # workers from initializing the database concurrently. Without this,
+        # concurrent workers race on DDL statements in migrations, on
+        # TestSuite metadata inserts in _load_schemas(), and on CREATE TABLE
+        # in create_tables(). On SQLite, file-level locking already
+        # serializes access.
+        is_postgres = self.engine.dialect.name == 'postgresql'
+        conn = self.engine.connect() if is_postgres else None
+        try:
+            if conn is not None:
+                conn.execute(sqlalchemy.text("SELECT pg_advisory_lock(1)"))
 
-        self.sessionmaker = sqlalchemy.orm.sessionmaker(self.engine)
+            # Update the database to the current version, if necessary.
+            lnt.server.db.migrate.update(self.engine)
 
-        self.testsuite = dict()
-        self._load_schemas()
+            self.sessionmaker = sqlalchemy.orm.sessionmaker(self.engine)
+
+            self.testsuite = dict()
+            self._load_schemas()
+        finally:
+            if conn is not None:
+                conn.execute(sqlalchemy.text("SELECT pg_advisory_unlock(1)"))
+                conn.close()
 
     def close(self):
         self.engine.dispose()

--- a/lnt/server/ui/app.py
+++ b/lnt/server/ui/app.py
@@ -198,7 +198,7 @@ class App(LNTExceptionLoggerFlask):
         handler = logging.StreamHandler()
         handler.setLevel(logging.DEBUG)
         handler.setFormatter(Formatter('%(levelname)s: %(message)s [in %(filename)s:%(lineno)d %(asctime)s]'))
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         logger.addHandler(handler)
 
         instance = lnt.server.instance.Instance.frompath(config_path)

--- a/lnt/server/ui/app.py
+++ b/lnt/server/ui/app.py
@@ -191,15 +191,18 @@ class App(LNTExceptionLoggerFlask):
         :param config_path: path to lnt config (directory or config file).
         :return: a LNT Flask App, ready to be loaded into a wsgi server.
         """
-        instance = lnt.server.instance.Instance.frompath(config_path)
-        app = App.create_with_instance(instance)
-
         # Always log to stderr. In production, the webserver is generally run
         # inside a Docker container where logging to stderr is the de facto
-        # standard.
+        # standard. Set this up before loading the instance so that migration
+        # and initialization messages are visible.
         handler = logging.StreamHandler()
         handler.setLevel(logging.DEBUG)
         handler.setFormatter(Formatter('%(levelname)s: %(message)s [in %(filename)s:%(lineno)d %(asctime)s]'))
+        logger.setLevel(logging.DEBUG)
+        logger.addHandler(handler)
+
+        instance = lnt.server.instance.Instance.frompath(config_path)
+        app = App.create_with_instance(instance)
         app.logger.addHandler(handler)
 
         return app

--- a/tests/server/db/ConcurrentInstanceInit.py
+++ b/tests/server/db/ConcurrentInstanceInit.py
@@ -43,7 +43,7 @@ lock = threading.Lock()
 
 def init_instance():
     try:
-        barrier.wait() # wait for all workers to arrive
+        barrier.wait()  # wait for all workers to arrive
         lnt.server.instance.Instance.frompath(instance_path)
     except Exception as e:
         with lock:

--- a/tests/server/db/ConcurrentInstanceInit.py
+++ b/tests/server/db/ConcurrentInstanceInit.py
@@ -1,0 +1,89 @@
+"""Verify that concurrent database initialization doesn't crash.
+
+Multiple gunicorn workers start simultaneously and each opens the same
+LNT instance, triggering V4DB.__init__() which runs migrate.update()
+and _load_schemas(). This test ensures that the full initialization
+path is safe under concurrent access.
+"""
+# RUN: rm -rf "%t.instance" "%t.pg.log"
+# RUN: %{utils}/with_postgres.sh %t.pg.log \
+# RUN:     %{utils}/with_temporary_instance.py %t.instance \
+# RUN:         -- python %s %t.instance
+
+import os
+import sys
+import threading
+import traceback
+
+import sqlalchemy
+
+import lnt.server.instance
+import lnt.server.db.migrate
+
+
+instance_path = sys.argv[1]
+
+# Drop all tables to simulate a fresh database, so that concurrent
+# Instance.frompath() calls must run the full initialization path
+# (migrations + schema loading) rather than finding everything
+# already in place.
+db_uri = os.environ['LNT_TEST_DB_URI']
+db_name = os.environ['LNT_TEST_DB_NAME']
+engine = sqlalchemy.create_engine('%s/%s' % (db_uri, db_name))
+with engine.begin() as conn:
+    conn.execute(sqlalchemy.text("DROP SCHEMA public CASCADE"))
+    conn.execute(sqlalchemy.text("CREATE SCHEMA public"))
+engine.dispose()
+
+NUM_WORKERS = 4
+barrier = threading.Barrier(NUM_WORKERS, timeout=60)
+errors = []
+lock = threading.Lock()
+
+
+def init_instance():
+    try:
+        barrier.wait() # wait for all workers to arrive
+        lnt.server.instance.Instance.frompath(instance_path)
+    except Exception as e:
+        with lock:
+            errors.append((threading.current_thread().name, e, traceback.format_exc()))
+
+
+threads = [threading.Thread(target=init_instance, name='worker-%d' % i)
+           for i in range(NUM_WORKERS)]
+for t in threads:
+    t.start()
+for t in threads:
+    t.join(timeout=120)
+
+hung = [t for t in threads if t.is_alive()]
+if hung:
+    print("FAIL: %d worker(s) still running after timeout" % len(hung))
+    sys.exit(1)
+
+if errors:
+    print("FAIL: %d of %d workers failed during concurrent initialization:"
+          % (len(errors), NUM_WORKERS))
+    for name, exc, tb in errors:
+        print("\n--- %s ---" % name)
+        print(tb)
+    sys.exit(1)
+
+# Verify the database is properly initialized.
+engine = sqlalchemy.create_engine('%s/%s' % (db_uri, db_name))
+session = sqlalchemy.orm.sessionmaker(engine)()
+
+sv = session.query(lnt.server.db.migrate.SchemaVersion) \
+    .filter_by(name='__core__').first()
+migrations = lnt.server.db.migrate._load_migrations()
+expected = migrations['__core__']['current_version']
+assert sv is not None, "SchemaVersion not found"
+assert sv.version == expected, \
+    "Expected version %d, got %d" % (expected, sv.version)
+
+session.close()
+engine.dispose()
+
+print("PASS: All %d workers completed concurrent initialization successfully "
+      "(schema version: %d)" % (NUM_WORKERS, sv.version))


### PR DESCRIPTION
When multiple gunicorn workers start simultaneously, they all call V4DB.__init__() which runs migrate.update() and _load_schemas(). Without serialization, concurrent workers race whenever a migration creates a table, adds a column, etc.

To fix this, we wrap the whole V4DB initialization path in a session-wide lock on Postgres. Also ensure that logging is enabled when we perform migrations -- previously migrations were not logged at all because the logger was not initialized yet.

The patch also adds an integration test that attempts to reproduce concurrency issues by creating a fresh DB and running the migrations concurrently, which I have confirmed to fail if the session-wide lock isn't added.

Assisted-by: Claude Code