### PR TITLE
Keep a test from printing ansi control characters

### DIFF
--- a/tests/lnttool/Profile.py
+++ b/tests/lnttool/Profile.py
@@ -13,4 +13,5 @@
 # RUN: mkdir -p %t
 # RUN: rm -rf %t/non_existing_output.lnt
 # RUN: lnt profile upgrade %S/Inputs/test.lntprof %t/non_existing_output.lnt
-# RUN: cat %t/non_existing_output.lnt
+# RUN: lnt profile getVersion %t/non_existing_output.lnt | filecheck --check-prefix=CHECK-UPGRADE %s
+# CHECK-UPGRADE: 2


### PR DESCRIPTION
This was breaking LIT's progress bar. Fix it by having filecheck verify that the upgrade was successful via a CHECK line.